### PR TITLE
Drop unused ext-http requirement from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "symfony/serializer": "7.3.*",
         "symfony/uid": "7.3.*",
         "symfony/validator": "7.3.*",
-        "symfony/yaml": "7.3.*",
-        "ext-http": "*"
+        "symfony/yaml": "7.3.*"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
## Co i po co

CI (GitHub Actions) jest czerwone od dawna: `composer install` pada na runnerze, bo `composer.json` wymaga rozszerzenia PECL **ext-http**, którego runner nie ma.

Diagnoza:
- kod nigdzie nie używa klas/funkcji pecl_http (sprawdzone grepem),
- kontener aplikacji też **nie ma** tego rozszerzenia,
- `composer.lock` nie wymagał zmiany po usunięciu wpisu → wymóg dopisano ręcznie już po ostatnim `composer update`, nigdy nie był realnie zainstalowany.

## Weryfikacja

- `composer validate` + `composer install` w kontenerze: OK
- Pełny Pest w Dockerze: **51 passed, 1086 assertions**
- Run CI (push) dla tego commita: [zielony](https://github.com/JacekSzczepaniak/battleship/actions/runs/29128725709) — pierwszy udany run od września 2025

Po merge CI na `main` powinno wrócić do zieleni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)