### PR TITLE
Fix air raid geometry: swapped axes and edge clamp skipping row/column 0

### DIFF
--- a/src/Application/Game/SendAirRaid.php
+++ b/src/Application/Game/SendAirRaid.php
@@ -21,7 +21,7 @@ final class SendAirRaid
         }
 
         $centralPoint = new Coordinate($x, $y);
-        $results = $game->sendAirRaid($centralPoint, new Area($centralPoint, $width, $height));
+        $results = $game->sendAirRaid($centralPoint, new Area($width, $height));
 
         $this->repo->save($game);
         return $results;

--- a/src/Domain/Game/Area.php
+++ b/src/Domain/Game/Area.php
@@ -2,12 +2,16 @@
 
 namespace App\Domain\Game;
 
+/**
+ * Rozmiar prostokątnego obszaru. W żądaniu nalotu width/height to pół-zasięgi
+ * od punktu centralnego (0 = pojedynczy wiersz/kolumna); w Ruleset::airRaidSize()
+ * — maksymalny pełny rozmiar obszaru w komórkach.
+ */
 final class Area
 {
-
-    public function __construct(Coordinate $start, public int $width, public int $height)
+    public function __construct(public readonly int $width, public readonly int $height)
     {
-        if ($width < 1 || $height < 1) {
+        if ($width < 0 || $height < 0) {
             throw new \InvalidArgumentException('Negative size');
         }
     }

--- a/src/Domain/Game/FunRuleset.php
+++ b/src/Domain/Game/FunRuleset.php
@@ -20,7 +20,7 @@ final class FunRuleset implements Ruleset
 
     public function airRaidSize(): Area
     {
-        return new Area(new Coordinate(2, 2), 3, 3);
+        return new Area(3, 3);
     }
 
     public function fireTorpedo(): bool

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -598,40 +598,42 @@ final class Game
         return $results;
     }
 
+    /**
+     * Air raid: ostrzeliwuje prostokąt wokół punktu centralnego.
+     * $area to pół-zasięgi (width → oś x, height → oś y), więc żądany obszar
+     * ma (2*width+1) × (2*height+1) komórek; przy krawędzi jest przycinany do planszy.
+     * Walidacja rozmiaru dotyczy obszaru ŻĄDANEGO (przed przycięciem) względem
+     * limitu z rulesetu (airRaidSize = maksymalny pełny rozmiar w komórkach).
+     *
+     * @return list<array{x:int,y:int,result:string}>
+     */
     public function sendAirRaid(Coordinate $start, Area $area): array
     {
         if (null === $this->board) {
             throw new \DomainException('Fleet not placed');
         }
 
-        //sprawdzam czy start jest na planszy
         $w = $this->ruleset->boardSize()->width;
         $h = $this->ruleset->boardSize()->height;
 
-        $x = $start->x;
-        $y = $start->y;
-
-        if ($x < 0 || $y < 0 || $x >= $w || $y >= $h) {
+        if ($start->x >= $w || $start->y >= $h) {
             throw new \DomainException('Air Raid start outside board');
         }
-        //(5-9)
-        $areaStartX = ($start->x - $area->height) > 0 ? $start->x - $area->height : 1;
-        $areaEndX = ($start->x + $area->height) >= $this->ruleset->boardSize()->height ?
-            $this->ruleset->boardSize()->height - 1 : $start->x + $area->height;
 
-        $areaStartY = ($start->y - $area->width) > 0 ? $start->y - $area->width : 1;
-        $areaEndY = ($start->y + $area->width) >= $this->ruleset->boardSize()->width ?
-            $this->ruleset->boardSize()->width - 1 : $start->y + $area->width;
-
-        if ($areaEndX - $areaStartX > $this->ruleset->airRaidSize()->width
-        || $areaEndY - $areaStartY > $this->ruleset->airRaidSize()->height) {
+        $max = $this->ruleset->airRaidSize();
+        if (2 * $area->width + 1 > $max->width || 2 * $area->height + 1 > $max->height) {
             throw new \DomainException('Air Raid area is oversize');
         }
 
+        $fromX = max(0, $start->x - $area->width);
+        $toX = min($w - 1, $start->x + $area->width);
+        $fromY = max(0, $start->y - $area->height);
+        $toY = min($h - 1, $start->y + $area->height);
+
         $results = [];
 
-        for ($x = $areaStartX; $x <= $areaEndX; ++$x) {
-            for ($y = $areaStartY; $y <= $areaEndY; ++$y) {
+        for ($x = $fromX; $x <= $toX; ++$x) {
+            for ($y = $fromY; $y <= $toY; ++$y) {
                 $r = $this->fireShot(new Coordinate($x, $y));
                 $results[] = ['x' => $x, 'y' => $y, 'result' => $r->value];
             }

--- a/src/Domain/Game/Ruleset.php
+++ b/src/Domain/Game/Ruleset.php
@@ -12,7 +12,7 @@ interface Ruleset
     public function allowedShips(): array;
 
     /**
-     * @return array<int,int> rozmiar nalotu
+     * Maksymalny pełny rozmiar obszaru nalotu (w komórkach).
      */
     public function airRaidSize(): Area;
 

--- a/tests/Unit/GameApiSendAirRaidTest.php
+++ b/tests/Unit/GameApiSendAirRaidTest.php
@@ -9,7 +9,7 @@ use App\Domain\Game\Game;
 use Tests\Support\FleetFactory;
 
 
-//nalot jest dozwolony na obszar 3x3
+//nalot jest dozwolony na obszar max 3x3 (Area = pół-zasięgi od centrum)
 
 it('pozwala przeprowadzić nalot na wybrany obszar', function () {
     $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
@@ -32,7 +32,7 @@ it('pozwala przeprowadzić nalot na wybrany obszar', function () {
         ['x' => 3, 'y' => 2, 'result' => 'miss',],
         ['x' => 3, 'y' => 3, 'result' => 'miss',],
     ],
-        $game->sendAirRaid($centralPoint, new Area($centralPoint, 1, 1))
+        $game->sendAirRaid($centralPoint, new Area(1, 1))
     );
 });
 
@@ -40,19 +40,24 @@ it('pozwala przeprowadzić nalot na wybrany obszar', function () {
 it('pozwala przeprowadzić nalot na wybrany obszar przy narożnikach', function () {
     $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
     $game->placeFleet(FleetFactory::classic10x10()); // ← najważniejsze: pełna, poprawna flota
-    $centralPoint = new Coordinate(1, 1);
 
-    //tablica 2x2
+    // Centrum (1,1): obszar przycięty do 0..2 × 0..2 — wiersz i kolumna 0 WCHODZĄ w nalot.
+    // Trafienia: czteromasztowiec (0,0)-(3,0) i trójmasztowiec (0,2)-(2,2);
+    // (2,2) domyka trójmasztowiec → sunk.
+    $centralPoint = new Coordinate(1, 1);
     self::assertSame(
         [
-            //pierwszy rząd
+            ['x' => 0, 'y' => 0, 'result' => 'hit',],
+            ['x' => 0, 'y' => 1, 'result' => 'miss',],
+            ['x' => 0, 'y' => 2, 'result' => 'hit',],
+            ['x' => 1, 'y' => 0, 'result' => 'hit',],
             ['x' => 1, 'y' => 1, 'result' => 'miss',],
             ['x' => 1, 'y' => 2, 'result' => 'hit',],
-            //drugi
+            ['x' => 2, 'y' => 0, 'result' => 'hit',],
             ['x' => 2, 'y' => 1, 'result' => 'miss',],
-            ['x' => 2, 'y' => 2, 'result' => 'hit',],
+            ['x' => 2, 'y' => 2, 'result' => 'sunk',],
         ],
-        $game->sendAirRaid($centralPoint, new Area($centralPoint, 1, 1))
+        $game->sendAirRaid($centralPoint, new Area(1, 1))
     );
 
     $centralPoint = new Coordinate(9, 5);
@@ -66,7 +71,38 @@ it('pozwala przeprowadzić nalot na wybrany obszar przy narożnikach', function 
             ['x' => 9, 'y' => 5, 'result' => 'miss',],
             ['x' => 9, 'y' => 6, 'result' => 'miss',],
         ],
-        $game->sendAirRaid($centralPoint, new Area($centralPoint, 1, 1))
+        $game->sendAirRaid($centralPoint, new Area(1, 1))
+    );
+});
+
+it('obejmuje pole (0,0) przy nalocie w sam róg planszy', function () {
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+
+    self::assertSame(
+        [
+            ['x' => 0, 'y' => 0, 'result' => 'hit',],
+            ['x' => 0, 'y' => 1, 'result' => 'miss',],
+            ['x' => 1, 'y' => 0, 'result' => 'hit',],
+            ['x' => 1, 'y' => 1, 'result' => 'miss',],
+        ],
+        $game->sendAirRaid(new Coordinate(0, 0), new Area(1, 1))
+    );
+});
+
+it('mapuje width na oś x, a height na oś y', function () {
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+
+    // height=1 rozciąga obszar w osi y: kolumna x=5, y od 4 do 6.
+    // (5,4) to część dwumasztowca (5,4)-(6,4) → hit; przy zamienionych osiach byłyby same pudła.
+    self::assertSame(
+        [
+            ['x' => 5, 'y' => 4, 'result' => 'hit',],
+            ['x' => 5, 'y' => 5, 'result' => 'miss',],
+            ['x' => 5, 'y' => 6, 'result' => 'miss',],
+        ],
+        $game->sendAirRaid(new Coordinate(5, 5), new Area(0, 1))
     );
 });
 
@@ -74,5 +110,18 @@ it('nie pozwala na zbyt duży nalot', function () {
     $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
     $game->placeFleet(FleetFactory::classic10x10()); // ← najważniejsze: pełna, poprawna flota
     $centralPoint = new Coordinate(5, 5);
-    $game->sendAirRaid($centralPoint, new Area($centralPoint, 3, 3));
+    $game->sendAirRaid($centralPoint, new Area(3, 3));
 })->throws(DomainException::class);
+
+it('nie pozwala na zbyt duży nalot także przy krawędzi (przycięcie nie maskuje rozmiaru)', function () {
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+    // żądany obszar 5x5 > limit 3x3, mimo że po przycięciu do planszy byłby mały
+    $game->sendAirRaid(new Coordinate(0, 0), new Area(2, 2));
+})->throws(DomainException::class, 'Air Raid area is oversize');
+
+it('odrzuca start nalotu poza planszą', function () {
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+    $game->sendAirRaid(new Coordinate(10, 5), new Area(1, 1));
+})->throws(DomainException::class, 'Air Raid start outside board');


### PR DESCRIPTION
Closes #7

## Problem

`Game::sendAirRaid()` miał trzy błędy:
1. **Pomylone osie** — zasięg dla x liczony z `area->height` i ograniczany wysokością planszy (i odwrotnie dla y). Na planszy 10×10 niewidoczne, na prostokątnej obszar wychodził poza planszę.
2. **Clamp od 1 zamiast od 0** — wiersz i kolumna 0 nigdy nie wchodziły w obszar nalotu. Bug był utrwalony w teście narożnika (oczekiwał 2×2 zamiast 3×3 dla centrum (1,1)).
3. **Walidacja rozmiaru po przycięciu** — nalot 5×5 zadany przy krawędzi przechodził, bo clamp zmniejszał obszar przed sprawdzeniem limitu.

## Zmiany

- poprawne mapowanie: `width` → oś x, `height` → oś y; clamp `max(0, …)`/`min(size-1, …)`
- walidacja żądanego rozmiaru (2·półzasięg+1 ≤ limit z `Ruleset::airRaidSize()`) przed przycięciem
- `Area`: usunięty nieużywany parametr `$start` (finding PHPStan), `readonly`, dopuszczony pół-zasięg 0 (nalot liniowy); udokumentowana semantyka (żądanie = pół-zasięgi, ruleset = pełny rozmiar)
- poprawiony `@return` w PHPDoc `Ruleset::airRaidSize()`

## Weryfikacja

Pełny Pest w Dockerze: **55 passed, 1092 assertions**. Nowe testy: nalot w róg (0,0), mapowanie osi (trafienie rozróżnia oś y od x), oversize przy krawędzi, start poza planszą. PHPStan L5: findings z Area/Ruleset zniknęły (zostały 2 pre-existing w PlaceFleet — zakres #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)