### PR TITLE
Introduce FleetGenerator port instead of APP_ENV check in PlaceFleet

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,3 +19,11 @@ services:
     # Infrastructure bindings
 #    App\Application\Ports\GameRepository: '@App\Infrastructure\Persistence\Doctrine\DoctrineGameRepository'
     App\Domain\Game\GameRepository: '@App\Infrastructure\Persistence\Doctrine\DoctrineGameRepository'
+
+    # Domain ports
+    App\Domain\Game\FleetGenerator: '@App\Domain\Game\RandomFleetGenerator'
+
+# Testy funkcjonalne wymagają przewidywalnej floty przeciwnika
+when@test:
+    services:
+        App\Domain\Game\FleetGenerator: '@App\Domain\Game\DeterministicFleetGenerator'

--- a/src/Application/Game/PlaceFleet.php
+++ b/src/Application/Game/PlaceFleet.php
@@ -3,6 +3,7 @@
 namespace App\Application\Game;
 
 use App\Domain\Game\Coordinate;
+use App\Domain\Game\FleetGenerator;
 use App\Domain\Game\GameRepository;
 use App\Domain\Game\Orientation;
 use App\Domain\Game\Ship;
@@ -10,8 +11,10 @@ use App\Domain\Shared\GameId;
 
 final class PlaceFleet
 {
-    public function __construct(private GameRepository $repo)
-    {
+    public function __construct(
+        private readonly GameRepository $repo,
+        private readonly FleetGenerator $opponentFleetGenerator,
+    ) {
     }
 
     /**
@@ -36,93 +39,8 @@ final class PlaceFleet
         $game->placeFleet($ships);
 
         // Po rozstawieniu floty gracza – wygeneruj flotę przeciwnika
-        $env = (string) ($_ENV['APP_ENV'] ?? $_SERVER['APP_ENV'] ?? 'dev');
-        $boardSize = $game->ruleset()->boardSize();
-        $opponent = [];
-        if ($env === 'test') {
-            // deterministyczny układ zgodny z klasycznym 10x10 (jak FleetFactory::classic10x10Array)
-            $opponent = [
-                ['x'=>0,'y'=>0,'o'=>'H','l'=>4],
-                ['x'=>0,'y'=>2,'o'=>'H','l'=>3],
-                ['x'=>6,'y'=>0,'o'=>'V','l'=>3],
-                ['x'=>5,'y'=>4,'o'=>'H','l'=>2],
-                ['x'=>9,'y'=>0,'o'=>'V','l'=>2],
-                ['x'=>3,'y'=>6,'o'=>'V','l'=>2],
-                ['x'=>0,'y'=>6,'o'=>'H','l'=>1],
-                ['x'=>1,'y'=>8,'o'=>'H','l'=>1],
-                ['x'=>5,'y'=>9,'o'=>'H','l'=>1],
-                ['x'=>8,'y'=>8,'o'=>'H','l'=>1],
-            ];
-            $oppShips = [];
-            foreach ($opponent as $s) {
-                $oppShips[] = new Ship(new Coordinate($s['x'], $s['y']), Orientation::from($s['o']), $s['l']);
-            }
-            $game->placeOpponentFleet($oppShips);
-        } else {
-            // losowy układ klasycznej floty dla rozmiaru planszy (domyślnie 10x10)
-            $oppShips = $this->generateRandomClassicFleet($boardSize->width, $boardSize->height);
-            $game->placeOpponentFleet($oppShips);
-        }
+        $game->placeOpponentFleet($this->opponentFleetGenerator->generate($game->ruleset()));
 
         $this->repo->save($game);
-    }
-
-    /**
-     * Generuje klasyczną flotę (1x4, 2x3, 3x2, 4x1) losowo na planszy o rozmiarze w×h.
-     * Stosuje proste wielokrotne próby aż do udanego rozstawienia.
-     * @return Ship[]
-     */
-    private function generateRandomClassicFleet(int $w, int $h): array
-    {
-        $lengths = [4,3,3,2,2,2,1,1,1,1];
-        $maxAttempts = 5000;
-        $attempt = 0;
-        while ($attempt++ < $maxAttempts) {
-            $ships = [];
-            try {
-                foreach ($lengths as $l) {
-                    $placed = false;
-                    $innerAttempts = 0;
-                    while (!$placed && $innerAttempts++ < 500) {
-                        $o = (random_int(0,1) === 0) ? Orientation::H : Orientation::V;
-                        if ($o === Orientation::H) {
-                            $x = random_int(0, max(0, $w - $l));
-                            $y = random_int(0, $h - 1);
-                        } else {
-                            $x = random_int(0, $w - 1);
-                            $y = random_int(0, max(0, $h - $l));
-                        }
-                        $candidate = new Ship(new Coordinate($x, $y), $o, $l);
-                        // Walidacja poprzez próbę położenia całości – użyj tymczasowej planszy
-                        $tmpShips = $ships;
-                        $tmpShips[] = $candidate;
-                        // użytkuj domenową Board przez Game::placeOpponentFleet – tutaj tylko weryfikacja przez Board::placeMany
-                        $board = new \App\Domain\Game\Board(new \App\Domain\Game\BoardSize($w, $h));
-                        $board->placeMany($tmpShips);
-                        $ships[] = $candidate;
-                        $placed = true;
-                    }
-                    if (!$placed) {
-                        throw new \RuntimeException('Failed to place ship');
-                    }
-                }
-                return $ships;
-            } catch (\Throwable) {
-                // spróbuj od nowa cały układ
-            }
-        }
-        // awaryjnie – wróć do deterministycznego klasyka
-        return [
-            new Ship(new Coordinate(0,0), Orientation::H, 4),
-            new Ship(new Coordinate(0,2), Orientation::H, 3),
-            new Ship(new Coordinate(6,0), Orientation::V, 3),
-            new Ship(new Coordinate(5,4), Orientation::H, 2),
-            new Ship(new Coordinate(9,0), Orientation::V, 2),
-            new Ship(new Coordinate(3,6), Orientation::V, 2),
-            new Ship(new Coordinate(0,6), Orientation::H, 1),
-            new Ship(new Coordinate(1,8), Orientation::H, 1),
-            new Ship(new Coordinate(5,9), Orientation::H, 1),
-            new Ship(new Coordinate(8,8), Orientation::H, 1),
-        ];
     }
 }

--- a/src/Domain/Game/DeterministicFleetGenerator.php
+++ b/src/Domain/Game/DeterministicFleetGenerator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Domain\Game;
+
+/**
+ * Stały, poprawny układ klasycznej floty (1x4, 2x3, 3x2, 4x1) w obrębie 10x10.
+ * Używany w env testowym (przewidywalne testy funkcjonalne — układ musi być
+ * zgodny z Tests\Support\FleetFactory::classic10x10()) oraz jako awaryjny
+ * fallback generatora losowego. Mieści się na każdej planszy >= 10x10.
+ */
+final class DeterministicFleetGenerator implements FleetGenerator
+{
+    public function generate(Ruleset $ruleset): array
+    {
+        return [
+            new Ship(new Coordinate(0, 0), Orientation::H, 4),
+            new Ship(new Coordinate(0, 2), Orientation::H, 3),
+            new Ship(new Coordinate(6, 0), Orientation::V, 3),
+            new Ship(new Coordinate(5, 4), Orientation::H, 2),
+            new Ship(new Coordinate(9, 0), Orientation::V, 2),
+            new Ship(new Coordinate(3, 6), Orientation::V, 2),
+            new Ship(new Coordinate(0, 6), Orientation::H, 1),
+            new Ship(new Coordinate(1, 8), Orientation::H, 1),
+            new Ship(new Coordinate(5, 9), Orientation::H, 1),
+            new Ship(new Coordinate(8, 8), Orientation::H, 1),
+        ];
+    }
+}

--- a/src/Domain/Game/FleetGenerator.php
+++ b/src/Domain/Game/FleetGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Domain\Game;
+
+/**
+ * Port generowania floty (np. dla przeciwnika po rozstawieniu floty gracza).
+ * Implementacja produkcyjna losuje układ, testowa zwraca deterministyczny.
+ */
+interface FleetGenerator
+{
+    /**
+     * Zwraca flotę zgodną z ruleset->allowedShips(), mieszczącą się na planszy
+     * rulesetu bez kolizji i styku (walidowalną przez Board::placeMany()).
+     *
+     * @return Ship[]
+     */
+    public function generate(Ruleset $ruleset): array;
+}

--- a/src/Domain/Game/RandomFleetGenerator.php
+++ b/src/Domain/Game/RandomFleetGenerator.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Domain\Game;
+
+/**
+ * Losowy układ floty wg ruleset->allowedShips(): dla każdego statku losuje
+ * pozycję do skutku (walidacja przez Board::place()), a przy zablokowanym
+ * układzie restartuje całość. Po wyczerpaniu prób wraca do układu
+ * deterministycznego, więc nigdy nie kończy się wyjątkiem.
+ */
+final class RandomFleetGenerator implements FleetGenerator
+{
+    private const MAX_FLEET_ATTEMPTS = 100;
+    private const MAX_SHIP_ATTEMPTS = 200;
+
+    public function __construct(
+        private readonly DeterministicFleetGenerator $fallback = new DeterministicFleetGenerator(),
+    ) {
+    }
+
+    public function generate(Ruleset $ruleset): array
+    {
+        $size = $ruleset->boardSize();
+        $lengths = $this->lengthsFrom($ruleset->allowedShips());
+
+        for ($attempt = 0; $attempt < self::MAX_FLEET_ATTEMPTS; ++$attempt) {
+            $ships = $this->tryPlaceFleet($lengths, $size);
+            if (null !== $ships) {
+                return $ships;
+            }
+        }
+
+        // statystycznie nieosiągalne dla klasycznej floty na 10x10, ale bez ryzyka pętli/wyjątku
+        return $this->fallback->generate($ruleset);
+    }
+
+    /**
+     * Rozwija mapę długość => liczba sztuk w listę długości, od najdłuższych
+     * (duże statki najtrudniej upchnąć, więc idą pierwsze).
+     *
+     * @param array<int,int> $allowedShips
+     * @return list<int>
+     */
+    private function lengthsFrom(array $allowedShips): array
+    {
+        krsort($allowedShips);
+        $lengths = [];
+        foreach ($allowedShips as $length => $count) {
+            for ($i = 0; $i < $count; ++$i) {
+                $lengths[] = $length;
+            }
+        }
+
+        return $lengths;
+    }
+
+    /**
+     * @param list<int> $lengths
+     * @return Ship[]|null null, gdy układu nie udało się domknąć
+     */
+    private function tryPlaceFleet(array $lengths, BoardSize $size): ?array
+    {
+        $board = new Board($size);
+        $ships = [];
+
+        foreach ($lengths as $length) {
+            $placed = false;
+            for ($i = 0; $i < self::MAX_SHIP_ATTEMPTS && !$placed; ++$i) {
+                $candidate = $this->randomShip($length, $size);
+                try {
+                    $board->place($candidate);
+                    $ships[] = $candidate;
+                    $placed = true;
+                } catch (\DomainException) {
+                    // kolizja lub styk – losuj dalej
+                }
+            }
+            if (!$placed) {
+                return null;
+            }
+        }
+
+        return $ships;
+    }
+
+    private function randomShip(int $length, BoardSize $size): Ship
+    {
+        $orientation = 0 === random_int(0, 1) ? Orientation::H : Orientation::V;
+
+        if (Orientation::H === $orientation) {
+            $x = random_int(0, max(0, $size->width - $length));
+            $y = random_int(0, $size->height - 1);
+        } else {
+            $x = random_int(0, $size->width - 1);
+            $y = random_int(0, max(0, $size->height - $length));
+        }
+
+        return new Ship(new Coordinate($x, $y), $orientation, $length);
+    }
+}

--- a/tests/Domain/Game/FleetGeneratorTest.php
+++ b/tests/Domain/Game/FleetGeneratorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Game;
+
+use App\Domain\Game\Board;
+use App\Domain\Game\BoardSize;
+use App\Domain\Game\ClassicRuleset;
+use App\Domain\Game\DeterministicFleetGenerator;
+use App\Domain\Game\RandomFleetGenerator;
+use App\Domain\Game\Ruleset;
+use App\Domain\Game\Ship;
+use PHPUnit\Framework\TestCase;
+
+final class FleetGeneratorTest extends TestCase
+{
+    /** @param Ship[] $ships */
+    private function assertValidFleet(array $ships, Ruleset $ruleset): void
+    {
+        // kompozycja zgodna z rulesetem
+        $got = [];
+        foreach ($ships as $ship) {
+            $got[$ship->length] = ($got[$ship->length] ?? 0) + 1;
+        }
+        $expected = $ruleset->allowedShips();
+        ksort($got);
+        ksort($expected);
+        self::assertSame($expected, $got, 'Fleet composition does not match ruleset');
+
+        // rozstawienie poprawne: brak kolizji/styku, w granicach planszy
+        $board = new Board($ruleset->boardSize());
+        $board->placeMany($ships); // rzuci DomainException przy błędnym układzie
+        self::assertCount(count($ships), $board->ships());
+    }
+
+    public function testDeterministicGeneratorReturnsValidClassicFleet(): void
+    {
+        $ruleset = new ClassicRuleset(new BoardSize(10, 10));
+        $this->assertValidFleet((new DeterministicFleetGenerator())->generate($ruleset), $ruleset);
+    }
+
+    public function testRandomGeneratorReturnsValidFleetEveryTime(): void
+    {
+        $ruleset = new ClassicRuleset(new BoardSize(10, 10));
+        $generator = new RandomFleetGenerator();
+
+        for ($i = 0; $i < 25; ++$i) {
+            $this->assertValidFleet($generator->generate($ruleset), $ruleset);
+        }
+    }
+
+    public function testRandomGeneratorSupportsRectangularBoard(): void
+    {
+        $ruleset = new ClassicRuleset(new BoardSize(12, 10));
+        $generator = new RandomFleetGenerator();
+
+        for ($i = 0; $i < 10; ++$i) {
+            $this->assertValidFleet($generator->generate($ruleset), $ruleset);
+        }
+    }
+
+    public function testRandomGeneratorProducesDifferentLayouts(): void
+    {
+        $ruleset = new ClassicRuleset(new BoardSize(10, 10));
+        $generator = new RandomFleetGenerator();
+
+        $key = static fn (array $ships): string => implode('|', array_map(
+            static fn (Ship $s) => "{$s->start->x}:{$s->start->y}:{$s->orientation->value}:{$s->length}",
+            $ships
+        ));
+
+        $layouts = [];
+        for ($i = 0; $i < 10; ++$i) {
+            $layouts[$key($generator->generate($ruleset))] = true;
+        }
+
+        // 10 losowań i wszystkie identyczne = generator nie losuje (fallback/bug)
+        self::assertGreaterThan(1, count($layouts), 'Random generator returned identical layouts');
+    }
+}

--- a/tests/Unit/Application/PlaceFleetTest.php
+++ b/tests/Unit/Application/PlaceFleetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Application\Game\CreateGame;
 use App\Application\Game\PlaceFleet;
+use App\Domain\Game\DeterministicFleetGenerator;
 use App\Infrastructure\Persistence\InMemory\InMemoryGameRepository;
 
 it('PlaceFleet zapisuje poprawnie rozstawioną flotę', function () {
@@ -11,7 +12,7 @@ it('PlaceFleet zapisuje poprawnie rozstawioną flotę', function () {
     $create = new CreateGame($repo);
     $game = $create->handle(12, 10);
 
-    $handler = new PlaceFleet($repo);
+    $handler = new PlaceFleet($repo, new DeterministicFleetGenerator());
     $ships = [
         ['x' => 0, 'y' => 0, 'o' => 'H', 'l' => 4],
         ['x' => 0, 'y' => 2, 'o' => 'H', 'l' => 3],
@@ -30,4 +31,6 @@ it('PlaceFleet zapisuje poprawnie rozstawioną flotę', function () {
     $reloaded = $repo->get($game->id());
     expect($reloaded)->not->toBeNull();
     expect($reloaded->fleet())->not->toBeNull();
+    // flota przeciwnika generowana automatycznie po rozstawieniu floty gracza
+    expect($reloaded->opponentFleet())->not->toBeNull();
 });


### PR DESCRIPTION
Closes #8

## Problem

`Application/Game/PlaceFleet` czytał `$_ENV[APP_ENV]` i dla `test` rozstawiał zahardkodowaną flotę przeciwnika — logika testowa w kodzie produkcyjnym. Kruchość tego rozwiązania już raz ugryzła: zahardkodowane `dev` przy debugowaniu zepsuło deterministykę testów (naprawione w ddc441a).

## Zmiany

- **`FleetGenerator`** (port w Domain) z dwiema implementacjami:
  - `RandomFleetGenerator` — kompozycja floty z `ruleset->allowedShips()` (nie hardkod), inkrementalna `Board` zamiast przebudowy planszy przy każdym kandydacie (stara pętla przy pierwszej kolizji restartowała cały układ), po wyczerpaniu prób fallback do układu deterministycznego — bez ścieżki wyjątku
  - `DeterministicFleetGenerator` — układ zgodny z `FleetFactory::classic10x10()` (testy funkcjonalne zatapiają go po współrzędnych)
- **DI**: `FleetGenerator → RandomFleetGenerator`, w `when@test` → `DeterministicFleetGenerator`
- `PlaceFleet` odchudzony o ~80 linii; zniknęły też 2 findings PHPStan

## Weryfikacja

Pełny Pest w Dockerze: **59 passed, 1166 assertions** (nowe testy: kompozycja + poprawność rozstawienia obu generatorów, plansza prostokątna 12×10, różnorodność losowań). PHPStan L5 na `src/Domain/Game` + `src/Application/Game`: **0 błędów**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)