### PR TITLE
Add PHPStan config and static analysis job to CI

### DIFF
--- a/.github/workflows/symfony-ci.yml
+++ b/.github/workflows/symfony-ci.yml
@@ -5,6 +5,27 @@ on:
     pull_request:
 
 jobs:
+    static-analysis:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.3'
+                  coverage: none
+
+            - name: Install dependencies
+              run: composer install --no-interaction --no-progress --prefer-dist
+
+            - name: PHPStan
+              run: ./vendor/bin/phpstan analyze --no-progress
+
+            - name: PHP-CS-Fixer (dry-run)
+              run: ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
+
     tests:
         runs-on: ubuntu-latest
 
@@ -41,25 +62,7 @@ jobs:
 
             - name: Install dependencies
               run: composer install --no-interaction --no-progress --prefer-dist
-            - name: Debug network
-              run: |
-                  echo "=== DATABASE_URL ==="
-                  echo "$DATABASE_URL"
-                  echo
-                  echo "=== TEST_DATABASE_URL ==="
-                  echo "$TEST_DATABASE_URL"
-                  echo
-                  echo "=== /etc/hosts ==="
-                  cat /etc/hosts
-                  echo
-                  echo "=== getent hosts postgres ==="
-                  getent hosts postgres || echo "Host 'postgres' not found"
-                  echo
-                  echo "=== nslookup postgres ==="
-                  nslookup postgres || echo "nslookup failed"
-                  echo
-                  echo "=== ping postgres ==="
-                  ping -c 3 postgres || echo "ping failed"
+
             - name: Wait for Postgres to be healthy
               run: |
                   for i in {1..30}; do
@@ -72,18 +75,7 @@ jobs:
                   done
               env:
                   PGPASSWORD: statki
-            - name: Show PHP-visible envs for DB
-              run: |
-                  php -r 'echo "PHP getenv DATABASE_URL: ", getenv("DATABASE_URL") ?: "(null)", PHP_EOL;'
-                  php -r 'echo "PHP getenv TEST_DATABASE_URL: ", getenv("TEST_DATABASE_URL") ?: "(null)", PHP_EOL;'
-            - name: Patch phpunit.xml(.dist) DSNs to 127.0.0.1 (if present)
-              run: |
-                  for f in phpunit.xml phpunit.xml.dist; do
-                    if [ -f "$f" ]; then
-                      echo "Patching $f"
-                      sed -E -i 's/@postgres/@127.0.0.1/g' "$f"
-                    fi
-                  done
+
             - name: Create database
               run: php bin/console doctrine:database:create --if-not-exists --env=test
 

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ pkg-dev: ## Doinstaluj pakiety deweloperskie (phpunit, pest, phpstan, cs-fixer, 
 migrate: ## Wykonaj migracje w env=dev
 	docker compose exec app php bin/console doctrine:migrations:migrate --no-interaction
 
-stan: ## Uruchom PHPStan (toleruj błędy wyjścia)
-	docker compose exec app ./vendor/bin/phpstan analyze || true
+stan: ## Uruchom PHPStan (konfiguracja w phpstan.neon)
+	docker compose exec app ./vendor/bin/phpstan analyze
 
 cs-fix: ## Uruchom PHP-CS-Fixer (bez cache, toleruj błędy)
 	docker compose exec app ./vendor/bin/php-cs-fixer fix --using-cache=no || true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+parameters:
+    level: 5
+    paths:
+        - src
+    ignoreErrors:
+        # Timestampy encji Doctrine są zapisywane do DB przez ORM — PHPStan bez
+        # rozszerzenia doctrine widzi je jako "never read".
+        -
+            identifier: property.onlyWritten
+            path: src/Infrastructure/Persistence/Doctrine/Entity/*
+
+    # tests/ poza analizą: testy pisane w Pest (closures) wymagałyby dedykowanego
+    # rozszerzenia PHPStan — do rozważenia osobno.

--- a/src/Application/Game/FireShot.php
+++ b/src/Application/Game/FireShot.php
@@ -36,7 +36,7 @@ final class FireShot
             throw new \DomainException('Game already finished');
         }
 
-        if ($game->turn() !== 'player') {
+        if ('player' !== $game->turn()) {
             throw new \DomainException('Not player turn');
         }
 

--- a/src/Application/Game/FireTorpedo.php
+++ b/src/Application/Game/FireTorpedo.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Application\Game;
 
 use App\Domain\Game\Coordinate;

--- a/src/Application/Game/GetShots.php
+++ b/src/Application/Game/GetShots.php
@@ -25,7 +25,7 @@ final class GetShots
         // Collect hit cells (hit or sunk)
         $hitSet = [];
         foreach ($shots as $s) {
-            if ($s['result'] === 'hit' || $s['result'] === 'sunk') {
+            if ('hit' === $s['result'] || 'sunk' === $s['result']) {
                 $hitSet[$s['x'].':'.$s['y']] = true;
             }
         }

--- a/src/Application/Game/SendAirRaid.php
+++ b/src/Application/Game/SendAirRaid.php
@@ -24,6 +24,7 @@ final class SendAirRaid
         $results = $game->sendAirRaid($centralPoint, new Area($width, $height));
 
         $this->repo->save($game);
+
         return $results;
     }
 }

--- a/src/Application/Game/SonarPing.php
+++ b/src/Application/Game/SonarPing.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Application\Game;
 
 use App\Domain\Game\Coordinate;

--- a/src/Domain/Game/ClassicRuleset.php
+++ b/src/Domain/Game/ClassicRuleset.php
@@ -28,5 +28,4 @@ final class ClassicRuleset implements Ruleset
     {
         throw new \DomainException('Not accepted in classic ruleset');
     }
-
 }

--- a/src/Domain/Game/Direction.php
+++ b/src/Domain/Game/Direction.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Domain\Game;
 
 enum Direction: string

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -29,6 +29,7 @@ final class Game
     /**
      * Strzały przeciwnika na planszę gracza (keys "x:y"), lustrzana struktura do $shots/$hits.
      * Używane przez mock AI i do projekcji overlayu na planszy gracza.
+     *
      * @var array<string,bool>
      */
     private array $opponentShots = [];
@@ -38,6 +39,7 @@ final class Game
     /**
      * Nieprzezroczysty stan AI przeciwnika (kształt zna wyłącznie implementacja AI).
      * Game tylko przechowuje go między requestami na potrzeby snapshotu.
+     *
      * @var array<string,mixed>
      */
     private array $aiState = [];
@@ -174,6 +176,7 @@ final class Game
 
     /**
      * Ustawia flotę przeciwnika (walidowana jak flota gracza) i buduje planszę przeciwnika.
+     *
      * @param Ship[] $ships
      */
     public function placeOpponentFleet(array $ships): void
@@ -191,6 +194,7 @@ final class Game
 
     /**
      * Używane przy odtwarzaniu ze snapshotu (bez walidacji biznesowej poza budową planszy).
+     *
      * @param Ship[] $ships
      */
     public function setOpponentFleetFromSnapshot(array $ships): void
@@ -454,7 +458,7 @@ final class Game
                 }
             }
 
-        $out[] = ['x' => $x, 'y' => $y, 'result' => $result];
+            $out[] = ['x' => $x, 'y' => $y, 'result' => $result];
         }
 
         return $out;

--- a/src/Domain/Game/RandomFleetGenerator.php
+++ b/src/Domain/Game/RandomFleetGenerator.php
@@ -39,6 +39,7 @@ final class RandomFleetGenerator implements FleetGenerator
      * (duże statki najtrudniej upchnąć, więc idą pierwsze).
      *
      * @param array<int,int> $allowedShips
+     *
      * @return list<int>
      */
     private function lengthsFrom(array $allowedShips): array
@@ -56,6 +57,7 @@ final class RandomFleetGenerator implements FleetGenerator
 
     /**
      * @param list<int> $lengths
+     *
      * @return Ship[]|null null, gdy układu nie udało się domknąć
      */
     private function tryPlaceFleet(array $lengths, BoardSize $size): ?array

--- a/src/Domain/Game/Shooter.php
+++ b/src/Domain/Game/Shooter.php
@@ -5,5 +5,6 @@ namespace App\Domain\Game;
 interface Shooter
 {
     public function nextShot(BoardReadModel $board): Coordinate;
+
     public function notify(Coordinate $c, ShotResult $result): void;
 }

--- a/src/Domain/Game/ShotResult.php
+++ b/src/Domain/Game/ShotResult.php
@@ -10,5 +10,4 @@ enum ShotResult: string
     case Hit = 'hit';
     case Sunk = 'sunk';
     case Duplicate = 'duplicate';
-
 }

--- a/src/Domain/Game/TargetBoard.php
+++ b/src/Domain/Game/TargetBoard.php
@@ -6,7 +6,10 @@ namespace App\Domain\Game;
 interface TargetBoard
 {
     public function size(): int;
+
     public function shoot(Coordinate $c): ShotResult;       // MISS/HIT/SUNK
+
     public function isDefeated(): bool;                     // czy wszystkie statki zatopione
+
     public function wasTried(Coordinate $c): bool;          // dla AI
 }

--- a/src/Domain/Game/TurnLoop.php
+++ b/src/Domain/Game/TurnLoop.php
@@ -5,10 +5,10 @@ namespace App\Domain\Game;
 final class TurnLoop
 {
     public function __construct(
-        private Shooter     $player1,         // np. HumanShooter albo drugi AI
+        private Shooter $player1,         // np. HumanShooter albo drugi AI
         private TargetBoard $player2Board, // plansza przeciwnika P2
-        private Shooter     $player2,          // AI
-        private TargetBoard $player1Board  // plansza P1
+        private Shooter $player2,          // AI
+        private TargetBoard $player1Board,  // plansza P1
     ) {
     }
 
@@ -25,7 +25,7 @@ final class TurnLoop
 
         $turn = 1;
         while (true) {
-            if ($turn === 1) {
+            if (1 === $turn) {
                 // Tura gracza 1 – strzela dopóki trafia (Hit/Sunk)
                 $shotsThisTurn = 0;
                 $maxThisTurn = $p1View->width() * $p1View->height(); // bezpiecznik tury
@@ -38,15 +38,15 @@ final class TurnLoop
                         return 1;
                     }
 
-                    $shotsThisTurn++;
-                    $overall++;
+                    ++$shotsThisTurn;
+                    ++$overall;
                     if ($shotsThisTurn >= $maxThisTurn) {
                         break;
                     }
                     if ($overall >= $maxOverallShots) {
                         throw new \RuntimeException('TurnLoop safety triggered: too many shots overall');
                     }
-                } while ($res === ShotResult::Hit || $res === ShotResult::Sunk);
+                } while (ShotResult::Hit === $res || ShotResult::Sunk === $res);
 
                 $turn = 2;
             } else {
@@ -62,15 +62,15 @@ final class TurnLoop
                         return 2;
                     }
 
-                    $shotsThisTurn++;
-                    $overall++;
+                    ++$shotsThisTurn;
+                    ++$overall;
                     if ($shotsThisTurn >= $maxThisTurn) {
                         break;
                     }
                     if ($overall >= $maxOverallShots) {
                         throw new \RuntimeException('TurnLoop safety triggered: too many shots overall');
                     }
-                } while ($res === ShotResult::Hit || $res === ShotResult::Sunk);
+                } while (ShotResult::Hit === $res || ShotResult::Sunk === $res);
 
                 $turn = 1;
             }

--- a/src/Infrastructure/Http/Controller/FireTorpedoController.php
+++ b/src/Infrastructure/Http/Controller/FireTorpedoController.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Infrastructure\Http\Controller;
 
 use App\Application\Game\FireTorpedo;

--- a/src/Infrastructure/Http/Controller/GameQueryController.php
+++ b/src/Infrastructure/Http/Controller/GameQueryController.php
@@ -49,7 +49,7 @@ final class GameQueryController
         $sunk = [];
         $hitSet = [];
         foreach ($hits as $h) {
-            $hitSet[$h[0] . ':' . $h[1]] = true;
+            $hitSet[$h[0].':'.$h[1]] = true;
         }
 
         $fleet = $game->fleet() ?? [];
@@ -99,8 +99,8 @@ final class GameQueryController
             ],
             // overlay trafień/pudeł przeciwnika na planszy gracza
             'playerUnderFireGrid' => [
-                'hits' => array_values(array_map(static fn(array $s) => [$s['x'],$s['y']], array_filter($oppShots, static fn(array $s) => in_array($s['result'], ['hit','sunk'], true)))) ,
-                'misses' => array_values(array_map(static fn(array $s) => [$s['x'],$s['y']], array_filter($oppShots, static fn(array $s) => $s['result'] === 'miss'))),
+                'hits' => array_values(array_map(static fn (array $s) => [$s['x'], $s['y']], array_filter($oppShots, static fn (array $s) => in_array($s['result'], ['hit', 'sunk'], true)))),
+                'misses' => array_values(array_map(static fn (array $s) => [$s['x'], $s['y']], array_filter($oppShots, static fn (array $s) => 'miss' === $s['result']))),
             ],
             'shotsCount' => count($shots),
             'finished' => $finished,

--- a/src/Infrastructure/Http/Controller/GameQueryController.php
+++ b/src/Infrastructure/Http/Controller/GameQueryController.php
@@ -7,7 +7,7 @@ use App\Domain\Game\Orientation;
 use App\Domain\Shared\GameId;
 use App\Infrastructure\Http\Error\ApiException;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Uid\Uuid;
 
 #[Route('/api/games')]
@@ -30,8 +30,8 @@ final class GameQueryController
         }
 
         $size = $game->ruleset()->boardSize();
-        $shots = method_exists($game, 'shotsWithResults') ? $game->shotsWithResults() : [];
-        $oppShots = method_exists($game, 'opponentShotsWithResults') ? $game->opponentShotsWithResults() : [];
+        $shots = $game->shotsWithResults();
+        $oppShots = $game->opponentShotsWithResults();
 
         // hits/misses sets
         $hits = [];
@@ -88,9 +88,9 @@ final class GameQueryController
             'id' => (string) $game->id(),
             'status' => $game->status()->value,
             'board' => ['w' => $size->width, 'h' => $size->height],
-            'mode' => method_exists($game, 'mode') ? $game->mode() : 'standard',
-            'opponent' => method_exists($game, 'opponent') ? $game->opponent() : 'mock',
-            'turn' => method_exists($game, 'turn') ? $turn : 'player',
+            'mode' => $game->mode(),
+            'opponent' => $game->opponent(),
+            'turn' => $turn,
             'playerFleet' => $playerFleet,
             'enemyFogGrid' => [
                 'hits' => $hits,

--- a/src/Infrastructure/Http/Controller/SendAirRaidController.php
+++ b/src/Infrastructure/Http/Controller/SendAirRaidController.php
@@ -4,8 +4,8 @@ namespace App\Infrastructure\Http\Controller;
 
 use App\Application\Game\SendAirRaid;
 use App\Infrastructure\Http\Error\ApiException;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Uid\Uuid;
 
@@ -41,8 +41,7 @@ final class SendAirRaidController
         $list = ($this->sendAirRaid)($id, $x, $y, $width, $height);
 
         return new JsonResponse([
-            'result' => $list, //list of {x,y,result?}
+            'result' => $list, // list of {x,y,result?}
         ]);
-
     }
 }

--- a/src/Infrastructure/Http/Controller/SonarController.php
+++ b/src/Infrastructure/Http/Controller/SonarController.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Infrastructure\Http\Controller;
 
 use App\Application\Game\SonarPing;

--- a/src/Infrastructure/Http/Error/ApiException.php
+++ b/src/Infrastructure/Http/Error/ApiException.php
@@ -10,7 +10,7 @@ final class ApiException extends \RuntimeException
         string $message,
         private readonly string $apiCode,
         private readonly int $httpStatus = 400,
-        ?\Throwable $previous = null
+        ?\Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Infrastructure/Http/Error/ExceptionSubscriber.php
+++ b/src/Infrastructure/Http/Error/ExceptionSubscriber.php
@@ -25,6 +25,7 @@ final class ExceptionSubscriber implements EventSubscriberInterface
         // ApiException — użyj danych z wyjątku
         if ($e instanceof ApiException) {
             $event->setResponse($this->jsonError($e->getMessage(), $e->apiCode(), $e->httpStatus()));
+
             return;
         }
 
@@ -33,6 +34,7 @@ final class ExceptionSubscriber implements EventSubscriberInterface
             $message = $e->getMessage() ?: 'Domain error';
             [$code, $status] = $this->mapDomainMessage($message);
             $event->setResponse($this->jsonError($message, $code, $status));
+
             return;
         }
 
@@ -42,14 +44,17 @@ final class ExceptionSubscriber implements EventSubscriberInterface
             $norm = strtolower($message);
             if (str_contains($norm, 'not found')) {
                 $event->setResponse($this->jsonError('Game not found', 'GAME_NOT_FOUND', 404));
+
                 return;
             }
             if (str_contains($norm, 'invalid game id') || str_contains($norm, 'uuid')) {
                 $event->setResponse($this->jsonError('Invalid game id', 'INVALID_GAME_ID', 400));
+
                 return;
             }
 
             $event->setResponse($this->jsonError($message, 'VALIDATION_ERROR', 400));
+
             return;
         }
 

--- a/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
+++ b/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
@@ -93,7 +93,7 @@ final class GameSnapshotMapper
         }
         if (isset($state['turn']) && is_string($state['turn'])) {
             $turn = $state['turn'];
-            $game->setTurn(in_array($turn, ['player','opponent','none'], true) ? $turn : 'player');
+            $game->setTurn(in_array($turn, ['player', 'opponent', 'none'], true) ? $turn : 'player');
         }
 
         // fleet from snapshot
@@ -154,7 +154,7 @@ final class GameSnapshotMapper
                     );
                 }
             }
-            if ($ships !== []) {
+            if ([] !== $ships) {
                 $game->setOpponentFleetFromSnapshot($ships);
             }
         }

--- a/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
+++ b/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
@@ -32,31 +32,22 @@ final class GameSnapshotMapper
 
         // opponent fleet (optional)
         $opponentFleet = null;
-        if (method_exists($game, 'opponentFleet')) {
-            /** @var Ship[]|null $opp */
-            $opp = $game->opponentFleet();
-            if (null !== $opp) {
-                $opponentFleet = array_map(function (Ship $s) {
-                    return [
-                        'x' => $s->start->x,
-                        'y' => $s->start->y,
-                        'o' => $s->orientation->value,
-                        'l' => $s->length,
-                    ];
-                }, $opp);
-            }
+        if (null !== $game->opponentFleet()) {
+            $opponentFleet = array_map(function (Ship $s) {
+                return [
+                    'x' => $s->start->x,
+                    'y' => $s->start->y,
+                    'o' => $s->orientation->value,
+                    'l' => $s->length,
+                ];
+            }, $game->opponentFleet());
         }
 
-        // include shots (with results) if domain exposes them
-        $shots = [];
-        if (method_exists($game, 'shotsWithResults')) {
-            /** @var list<array{x:int,y:int,result:string}> $withResults */
-            $withResults = $game->shotsWithResults();
-            $shots = array_map(
-                static fn (array $s) => ['x' => $s['x'], 'y' => $s['y'], 'r' => $s['result']],
-                $withResults
-            );
-        }
+        // shots with results
+        $shots = array_map(
+            static fn (array $s) => ['x' => $s['x'], 'y' => $s['y'], 'r' => $s['result']],
+            $game->shotsWithResults()
+        );
 
         return [
             'status' => $game->status()->value,
@@ -66,13 +57,11 @@ final class GameSnapshotMapper
             ],
             'fleet' => $fleet,
             'shots' => $shots,
-            // opponent shots (mock AI) snapshot – optional
-            'opponentShots' => method_exists($game, 'opponentShotsWithResults')
-                ? array_map(
-                    static fn (array $s) => ['x' => $s['x'], 'y' => $s['y'], 'r' => $s['result']],
-                    $game->opponentShotsWithResults()
-                )
-                : [],
+            // opponent shots (AI) snapshot
+            'opponentShots' => array_map(
+                static fn (array $s) => ['x' => $s['x'], 'y' => $s['y'], 'r' => $s['result']],
+                $game->opponentShotsWithResults()
+            ),
             // opponent fleet snapshot – optional
             'opponentFleet' => $opponentFleet,
             // Stan AI przeciwnika (kształt zna HuntTargetAI) – opcjonalnie
@@ -134,43 +123,7 @@ final class GameSnapshotMapper
                 }
             }
 
-            // preferred: domain setter (if available)
-            if (method_exists($game, 'setShotsFromSnapshot')) {
-                $game->setShotsFromSnapshot($shots);
-            } else {
-                // fallback: reflection — set 'shots' and compute 'hits'
-                $ref = new \ReflectionObject($game);
-
-                // build 'x:y' => true map for shots
-                $shotMap = [];
-                foreach ($shots as $s) {
-                    $key = $s['x'].':'.$s['y'];
-                    $shotMap[$key] = true;
-                }
-
-                // set private $shots if present
-                if ($ref->hasProperty('shots')) {
-                    $p = $ref->getProperty('shots');
-                    $p->setValue($game, $shotMap);
-                }
-
-                // compute hits based on current fleet
-                $hitMap = [];
-                $fleet = $game->fleet() ?? [];
-                foreach ($fleet as $ship) {
-                    foreach ($this->cellsFor($ship) as $cellKey) {
-                        if (isset($shotMap[$cellKey])) {
-                            $hitMap[$cellKey] = true;
-                        }
-                    }
-                }
-
-                // set private $hits if present
-                if ($ref->hasProperty('hits')) {
-                    $p = $ref->getProperty('hits');
-                    $p->setValue($game, $hitMap);
-                }
-            }
+            $game->setShotsFromSnapshot($shots);
         }
 
         // opponent shots from snapshot (optional)
@@ -186,39 +139,11 @@ final class GameSnapshotMapper
                 }
             }
 
-            if (method_exists($game, 'setOpponentShotsFromSnapshot')) {
-                $game->setOpponentShotsFromSnapshot($oppShots);
-            } else {
-                // reflection fallback (analogicznie jak dla shots)
-                $ref = new \ReflectionObject($game);
-                $shotMap = [];
-                foreach ($oppShots as $s) {
-                    $shotMap[$s['x'].':'.$s['y']] = true;
-                }
-                if ($ref->hasProperty('opponentShots')) {
-                    $p = $ref->getProperty('opponentShots');
-                    $p->setValue($game, $shotMap);
-                }
-
-                // compute opponentHits from fleet
-                $hitMap = [];
-                $fleet = $game->fleet() ?? [];
-                foreach ($fleet as $ship) {
-                    foreach ($this->cellsFor($ship) as $cellKey) {
-                        if (isset($shotMap[$cellKey])) {
-                            $hitMap[$cellKey] = true;
-                        }
-                    }
-                }
-                if ($ref->hasProperty('opponentHits')) {
-                    $p = $ref->getProperty('opponentHits');
-                    $p->setValue($game, $hitMap);
-                }
-            }
+            $game->setOpponentShotsFromSnapshot($oppShots);
         }
 
         // opponent fleet from snapshot (optional)
-        if (!empty($state['opponentFleet']) && is_array($state['opponentFleet']) && method_exists($game, 'setOpponentFleetFromSnapshot')) {
+        if (!empty($state['opponentFleet']) && is_array($state['opponentFleet'])) {
             $ships = [];
             foreach ($state['opponentFleet'] as $s) {
                 if (isset($s['x'], $s['y'], $s['o'], $s['l'])) {
@@ -247,20 +172,5 @@ final class GameSnapshotMapper
         $board = $data['board'] ?? ['w' => 10, 'h' => 10];
 
         return new ClassicRuleset(new BoardSize((int) $board['w'], (int) $board['h']));
-    }
-
-    /**
-     * @return list<string> ship cell keys in "x:y" format
-     */
-    private function cellsFor(Ship $ship): array
-    {
-        $out = [];
-        for ($i = 0; $i < $ship->length; ++$i) {
-            $x = $ship->start->x + (Orientation::H === $ship->orientation ? $i : 0);
-            $y = $ship->start->y + (Orientation::V === $ship->orientation ? $i : 0);
-            $out[] = $x.':'.$y;
-        }
-
-        return $out;
     }
 }

--- a/tests/Domain/Game/AI/HuntTargetAITest.php
+++ b/tests/Domain/Game/AI/HuntTargetAITest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Domain\Game\AI;
@@ -32,7 +31,7 @@ final class HuntTargetAITest extends TestCase
 
             public function wasTried(Coordinate $c): bool
             {
-                return $this->tried[$c->x . ':' . $c->y] ?? false;
+                return $this->tried[$c->x.':'.$c->y] ?? false;
             }
         };
     }
@@ -43,13 +42,13 @@ final class HuntTargetAITest extends TestCase
         $board = $this->readModel(10);
 
         $seen = [];
-        for ($i = 0; $i < 100; $i++) {
+        for ($i = 0; $i < 100; ++$i) {
             $c = $ai->nextShot($board);
             self::assertGreaterThanOrEqual(0, $c->x);
             self::assertGreaterThanOrEqual(0, $c->y);
             self::assertLessThan(10, $c->x);
             self::assertLessThan(10, $c->y);
-            $k = $c->x . ':' . $c->y;
+            $k = $c->x.':'.$c->y;
             self::assertFalse(isset($seen[$k]), "Duplicate coordinate generated: $k");
             $seen[$k] = true;
             // symulujemy MISS, żeby AI szukało dalej
@@ -71,9 +70,9 @@ final class HuntTargetAITest extends TestCase
             '3:2' => true, '1:2' => true, '2:3' => true, '2:1' => true,
         ];
         $seen = [];
-        for ($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; ++$i) {
             $c = $ai->nextShot($board);
-            $k = $c->x . ':' . $c->y;
+            $k = $c->x.':'.$c->y;
             $seen[$k] = true;
             // nie powiadamiamy – chcemy wyssać kolejkę kandydatów
         }
@@ -95,9 +94,9 @@ final class HuntTargetAITest extends TestCase
         $ai->notify($second, ShotResult::Hit);
 
         $candidates = [];
-        for ($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; ++$i) {
             $c = $ai->nextShot($board);
-            $candidates[$c->x . ':' . $c->y] = true;
+            $candidates[$c->x.':'.$c->y] = true;
             // nie powiadamiamy, aby przejrzeć wszystkie bieżące kandydaty
         }
 
@@ -126,7 +125,7 @@ final class HuntTargetAITest extends TestCase
         $board = $this->readModel(10);
 
         // Zbierz kilka strzałów – suma x+y powinna być parzysta (offset 0)
-        for ($i = 0; $i < 20; $i++) {
+        for ($i = 0; $i < 20; ++$i) {
             $c = $ai->nextShot($board);
             self::assertSame(0, ($c->x + $c->y) % 2, 'Expected checkerboard parity 0');
             $ai->notify($c, ShotResult::Miss);
@@ -138,7 +137,7 @@ final class HuntTargetAITest extends TestCase
         $ai = new HuntTargetAI(checkerboardMinSize: null);
         $board = $this->readModel(12, height: 10);
 
-        for ($i = 0; $i < 60; $i++) {
+        for ($i = 0; $i < 60; ++$i) {
             $c = $ai->nextShot($board);
             self::assertLessThan(12, $c->x);
             self::assertLessThan(10, $c->y);
@@ -157,9 +156,9 @@ final class HuntTargetAITest extends TestCase
 
         // Odtworzone AI powinno kontynuować dobijanie: 4 sąsiadów trafienia
         $expected = ['5:4' => true, '3:4' => true, '4:5' => true, '4:3' => true];
-        for ($i = 0; $i < 4; $i++) {
+        for ($i = 0; $i < 4; ++$i) {
             $c = $restored->nextShot($board);
-            $k = $c->x . ':' . $c->y;
+            $k = $c->x.':'.$c->y;
             self::assertArrayHasKey($k, $expected, "Unexpected candidate $k after restore");
             unset($expected[$k]);
         }
@@ -178,9 +177,9 @@ final class HuntTargetAITest extends TestCase
         $board = $this->readModel(3, $tried, height: 3);
 
         $seen = [];
-        for ($i = 0; $i < 6; $i++) { // 9 pól - 3 ostrzelane w granicach planszy = 6 wolnych
+        for ($i = 0; $i < 6; ++$i) { // 9 pól - 3 ostrzelane w granicach planszy = 6 wolnych
             $c = $ai->nextShot($board);
-            $k = $c->x . ':' . $c->y;
+            $k = $c->x.':'.$c->y;
             self::assertArrayNotHasKey($k, $tried, "AI repeated an already tried cell: $k");
             self::assertArrayNotHasKey($k, $seen, "AI repeated its own shot: $k");
             $seen[$k] = true;
@@ -197,17 +196,17 @@ final class HuntTargetAITest extends TestCase
         $ai->notify(new Coordinate(0, 0), ShotResult::Hit);
 
         $allowed = ['1:0' => true, '0:1' => true];
-        for ($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; ++$i) {
             $c = $ai->nextShot($board);
-            self::assertArrayHasKey($c->x . ':' . $c->y, $allowed);
+            self::assertArrayHasKey($c->x.':'.$c->y, $allowed);
         }
     }
 
     public function testThrowsWhenBoardExhausted(): void
     {
         $tried = [];
-        for ($x = 0; $x < 2; $x++) {
-            for ($y = 0; $y < 2; $y++) {
+        for ($x = 0; $x < 2; ++$x) {
+            for ($y = 0; $y < 2; ++$y) {
                 $tried["$x:$y"] = true;
             }
         }

--- a/tests/Domain/Game/BoardPlacementTest.php
+++ b/tests/Domain/Game/BoardPlacementTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Domain\Game;

--- a/tests/Domain/Game/TurnLoopTest.php
+++ b/tests/Domain/Game/TurnLoopTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Domain\Game;
@@ -21,26 +20,30 @@ final class TurnLoopTest extends TestCase
         return new class($shotsAndResultsPerTurn) implements Shooter {
             private int $turnIdx = 0;
             private int $shotIdx = 0;
+
             /** @var array<int,array<int,array{c:array{0:int,1:int},r:ShotResult}>> */
-            public function __construct(private array $plan) {}
+            public function __construct(private array $plan)
+            {
+            }
 
             public function nextShot(BoardReadModel $board): Coordinate
             {
                 $entry = $this->plan[$this->turnIdx][$this->shotIdx] ?? null;
-                if ($entry === null) {
+                if (null === $entry) {
                     return new Coordinate(0, 0);
                 }
+
                 return new Coordinate($entry['c'][0], $entry['c'][1]);
             }
 
             public function notify(Coordinate $c, ShotResult $result): void
             {
-                $this->shotIdx++;
+                ++$this->shotIdx;
                 $entry = $this->plan[$this->turnIdx][$this->shotIdx - 1] ?? null;
 
                 // koniec tury po MISS lub DUPLICATE
-                if ($entry && ($entry['r'] === ShotResult::Miss || $entry['r'] === ShotResult::Duplicate)) {
-                    $this->turnIdx++;
+                if ($entry && (ShotResult::Miss === $entry['r'] || ShotResult::Duplicate === $entry['r'])) {
+                    ++$this->turnIdx;
                     $this->shotIdx = 0;
                 }
             }
@@ -52,17 +55,34 @@ final class TurnLoopTest extends TestCase
         // results – sekwencja wyników zwracanych przez kolejne shoot()
         return new class($results, $size) implements TargetBoard {
             private int $i = -1;
-            public function __construct(private array $results, private int $size) {}
-            public function size(): int { return $this->size; }
-            public function wasTried(Coordinate $c): bool { return false; }
-            public function shoot(Coordinate $c): ShotResult {
-                $this->i++;
+
+            public function __construct(private array $results, private int $size)
+            {
+            }
+
+            public function size(): int
+            {
+                return $this->size;
+            }
+
+            public function wasTried(Coordinate $c): bool
+            {
+                return false;
+            }
+
+            public function shoot(Coordinate $c): ShotResult
+            {
+                ++$this->i;
+
                 return $this->results[$this->i] ?? ShotResult::Miss;
             }
-            public function isDefeated(): bool {
+
+            public function isDefeated(): bool
+            {
                 if ($this->i < 0) {
                     return false;
                 }
+
                 return ($this->results[$this->i] ?? null) === ShotResult::Sunk;
             }
         };
@@ -80,11 +100,11 @@ final class TurnLoopTest extends TestCase
         $p1Board = $this->stubBoard([ShotResult::Miss]); // nieistotne, P2 strzela raz
 
         $p1 = $this->stubShooter([
-            [ ['c'=>[0,0], 'r'=>ShotResult::Hit], ['c'=>[0,1], 'r'=>ShotResult::Hit], ['c'=>[0,2], 'r'=>ShotResult::Miss] ],
-            [ ['c'=>[0,3], 'r'=>ShotResult::Sunk] ],
+            [['c' => [0, 0], 'r' => ShotResult::Hit], ['c' => [0, 1], 'r' => ShotResult::Hit], ['c' => [0, 2], 'r' => ShotResult::Miss]],
+            [['c' => [0, 3], 'r' => ShotResult::Sunk]],
         ]);
         $p2 = $this->stubShooter([
-            [ ['c'=>[1,1], 'r'=>ShotResult::Miss] ],
+            [['c' => [1, 1], 'r' => ShotResult::Miss]],
         ]);
 
         $loop = new TurnLoop($p1, $p2Board, $p2, $p1Board);
@@ -99,8 +119,8 @@ final class TurnLoopTest extends TestCase
         $p2Board = $this->stubBoard([ShotResult::Sunk]);
         $p1Board = $this->stubBoard([ShotResult::Miss]);
 
-        $p1 = $this->stubShooter([[ ['c'=>[1,1], 'r'=>ShotResult::Sunk] ]]);
-        $p2 = $this->stubShooter([[ ['c'=>[2,2], 'r'=>ShotResult::Miss] ]]);
+        $p1 = $this->stubShooter([[['c' => [1, 1], 'r' => ShotResult::Sunk]]]);
+        $p2 = $this->stubShooter([[['c' => [2, 2], 'r' => ShotResult::Miss]]]);
 
         $loop = new TurnLoop($p1, $p2Board, $p2, $p1Board);
         $winner = $loop->play();
@@ -114,12 +134,12 @@ final class TurnLoopTest extends TestCase
         $p2Board = $this->stubBoard([ShotResult::Miss, ShotResult::Sunk]);
 
         $p1 = $this->stubShooter([
-            [ ['c'=>[0,0], 'r'=>ShotResult::Duplicate] ], // tura 1
-            [ ['c'=>[0,1], 'r'=>ShotResult::Miss] ],      // tura 3
+            [['c' => [0, 0], 'r' => ShotResult::Duplicate]], // tura 1
+            [['c' => [0, 1], 'r' => ShotResult::Miss]],      // tura 3
         ]);
         $p2 = $this->stubShooter([
-            [ ['c'=>[1,1], 'r'=>ShotResult::Miss] ],      // tura 2
-            [ ['c'=>[1,2], 'r'=>ShotResult::Sunk] ],      // tura 4 – zwycięstwo P2
+            [['c' => [1, 1], 'r' => ShotResult::Miss]],      // tura 2
+            [['c' => [1, 2], 'r' => ShotResult::Sunk]],      // tura 4 – zwycięstwo P2
         ]);
 
         $loop = new TurnLoop($p1, $p1Board, $p2, $p2Board);

--- a/tests/Functional/GameApiSonarTest.php
+++ b/tests/Functional/GameApiSonarTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Functional;
@@ -60,7 +59,7 @@ final class GameApiSonarTest extends WebTestCase
         // Map results to "x:y" => occupied
         $byKey = [];
         foreach ($results as $r) {
-            $byKey[$r['x'] . ':' . $r['y']] = (bool)$r['occupied'];
+            $byKey[$r['x'].':'.$r['y']] = (bool) $r['occupied'];
         }
 
         // Expected scanned coordinates within bounds for radius=3 from (0,0)
@@ -102,7 +101,7 @@ final class GameApiSonarTest extends WebTestCase
         $id = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR)['id'];
 
         // place classic fleet
-        $fleet = \Tests\Support\FleetFactory::classic10x10Array();
+        $fleet = FleetFactory::classic10x10Array();
         $client->request(
             'POST',
             "/api/games/$id/fleet",
@@ -125,6 +124,6 @@ final class GameApiSonarTest extends WebTestCase
         self::assertCount(1, $results);
         self::assertSame(0, $results[0]['x']);
         self::assertSame(6, $results[0]['y']);
-        self::assertTrue((bool)$results[0]['occupied']); // single ship at (0,6)
+        self::assertTrue((bool) $results[0]['occupied']); // single ship at (0,6)
     }
 }

--- a/tests/Functional/GameApiSonarValidationTest.php
+++ b/tests/Functional/GameApiSonarValidationTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Functional;

--- a/tests/Functional/GameApiTorpedoValidationTest.php
+++ b/tests/Functional/GameApiTorpedoValidationTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Functional;

--- a/tests/Integration/DoctrineGameRepositoryShotsTest.php
+++ b/tests/Integration/DoctrineGameRepositoryShotsTest.php
@@ -8,7 +8,6 @@ use App\Domain\Game\ClassicRuleset;
 use App\Domain\Game\Coordinate;
 use App\Domain\Game\Game;
 use App\Domain\Game\GameRepository;
-use App\Domain\Game\Orientation;
 use App\Domain\Shared\GameId;
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/tests/Unit/GameApiSendAirRaidTest.php
+++ b/tests/Unit/GameApiSendAirRaidTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 use App\Domain\Game\Area;
 use App\Domain\Game\BoardSize;
 use App\Domain\Game\Coordinate;
@@ -8,34 +7,32 @@ use App\Domain\Game\FunRuleset;
 use App\Domain\Game\Game;
 use Tests\Support\FleetFactory;
 
-
-//nalot jest dozwolony na obszar max 3x3 (Area = pół-zasięgi od centrum)
+// nalot jest dozwolony na obszar max 3x3 (Area = pół-zasięgi od centrum)
 
 it('pozwala przeprowadzić nalot na wybrany obszar', function () {
     $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
     $game->placeFleet(FleetFactory::classic10x10()); // ← najważniejsze: pełna, poprawna flota
     $centralPoint = new Coordinate(2, 2);
 
-    //tablica 3x3
+    // tablica 3x3
     self::assertSame(
         [
-        //pierwszy rząd
-        ['x' => 1, 'y' => 1, 'result' => 'miss',],
-        ['x' => 1, 'y' => 2, 'result' => 'hit',],
-        ['x' => 1, 'y' => 3, 'result' => 'miss',],
-        //drugi
-        ['x' => 2, 'y' => 1, 'result' => 'miss',],
-        ['x' => 2, 'y' => 2, 'result' => 'hit',],
-        ['x' => 2, 'y' => 3, 'result' => 'miss',],
-        //trzeci
-        ['x' => 3, 'y' => 1, 'result' => 'miss',],
-        ['x' => 3, 'y' => 2, 'result' => 'miss',],
-        ['x' => 3, 'y' => 3, 'result' => 'miss',],
-    ],
+            // pierwszy rząd
+            ['x' => 1, 'y' => 1, 'result' => 'miss'],
+            ['x' => 1, 'y' => 2, 'result' => 'hit'],
+            ['x' => 1, 'y' => 3, 'result' => 'miss'],
+            // drugi
+            ['x' => 2, 'y' => 1, 'result' => 'miss'],
+            ['x' => 2, 'y' => 2, 'result' => 'hit'],
+            ['x' => 2, 'y' => 3, 'result' => 'miss'],
+            // trzeci
+            ['x' => 3, 'y' => 1, 'result' => 'miss'],
+            ['x' => 3, 'y' => 2, 'result' => 'miss'],
+            ['x' => 3, 'y' => 3, 'result' => 'miss'],
+        ],
         $game->sendAirRaid($centralPoint, new Area(1, 1))
     );
 });
-
 
 it('pozwala przeprowadzić nalot na wybrany obszar przy narożnikach', function () {
     $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
@@ -47,15 +44,15 @@ it('pozwala przeprowadzić nalot na wybrany obszar przy narożnikach', function 
     $centralPoint = new Coordinate(1, 1);
     self::assertSame(
         [
-            ['x' => 0, 'y' => 0, 'result' => 'hit',],
-            ['x' => 0, 'y' => 1, 'result' => 'miss',],
-            ['x' => 0, 'y' => 2, 'result' => 'hit',],
-            ['x' => 1, 'y' => 0, 'result' => 'hit',],
-            ['x' => 1, 'y' => 1, 'result' => 'miss',],
-            ['x' => 1, 'y' => 2, 'result' => 'hit',],
-            ['x' => 2, 'y' => 0, 'result' => 'hit',],
-            ['x' => 2, 'y' => 1, 'result' => 'miss',],
-            ['x' => 2, 'y' => 2, 'result' => 'sunk',],
+            ['x' => 0, 'y' => 0, 'result' => 'hit'],
+            ['x' => 0, 'y' => 1, 'result' => 'miss'],
+            ['x' => 0, 'y' => 2, 'result' => 'hit'],
+            ['x' => 1, 'y' => 0, 'result' => 'hit'],
+            ['x' => 1, 'y' => 1, 'result' => 'miss'],
+            ['x' => 1, 'y' => 2, 'result' => 'hit'],
+            ['x' => 2, 'y' => 0, 'result' => 'hit'],
+            ['x' => 2, 'y' => 1, 'result' => 'miss'],
+            ['x' => 2, 'y' => 2, 'result' => 'sunk'],
         ],
         $game->sendAirRaid($centralPoint, new Area(1, 1))
     );
@@ -64,12 +61,12 @@ it('pozwala przeprowadzić nalot na wybrany obszar przy narożnikach', function 
 
     self::assertSame(
         [
-            ['x' => 8, 'y' => 4, 'result' => 'miss',],
-            ['x' => 8, 'y' => 5, 'result' => 'miss',],
-            ['x' => 8, 'y' => 6, 'result' => 'miss',],
-            ['x' => 9, 'y' => 4, 'result' => 'miss',],
-            ['x' => 9, 'y' => 5, 'result' => 'miss',],
-            ['x' => 9, 'y' => 6, 'result' => 'miss',],
+            ['x' => 8, 'y' => 4, 'result' => 'miss'],
+            ['x' => 8, 'y' => 5, 'result' => 'miss'],
+            ['x' => 8, 'y' => 6, 'result' => 'miss'],
+            ['x' => 9, 'y' => 4, 'result' => 'miss'],
+            ['x' => 9, 'y' => 5, 'result' => 'miss'],
+            ['x' => 9, 'y' => 6, 'result' => 'miss'],
         ],
         $game->sendAirRaid($centralPoint, new Area(1, 1))
     );
@@ -81,10 +78,10 @@ it('obejmuje pole (0,0) przy nalocie w sam róg planszy', function () {
 
     self::assertSame(
         [
-            ['x' => 0, 'y' => 0, 'result' => 'hit',],
-            ['x' => 0, 'y' => 1, 'result' => 'miss',],
-            ['x' => 1, 'y' => 0, 'result' => 'hit',],
-            ['x' => 1, 'y' => 1, 'result' => 'miss',],
+            ['x' => 0, 'y' => 0, 'result' => 'hit'],
+            ['x' => 0, 'y' => 1, 'result' => 'miss'],
+            ['x' => 1, 'y' => 0, 'result' => 'hit'],
+            ['x' => 1, 'y' => 1, 'result' => 'miss'],
         ],
         $game->sendAirRaid(new Coordinate(0, 0), new Area(1, 1))
     );
@@ -98,9 +95,9 @@ it('mapuje width na oś x, a height na oś y', function () {
     // (5,4) to część dwumasztowca (5,4)-(6,4) → hit; przy zamienionych osiach byłyby same pudła.
     self::assertSame(
         [
-            ['x' => 5, 'y' => 4, 'result' => 'hit',],
-            ['x' => 5, 'y' => 5, 'result' => 'miss',],
-            ['x' => 5, 'y' => 6, 'result' => 'miss',],
+            ['x' => 5, 'y' => 4, 'result' => 'hit'],
+            ['x' => 5, 'y' => 5, 'result' => 'miss'],
+            ['x' => 5, 'y' => 6, 'result' => 'miss'],
         ],
         $game->sendAirRaid(new Coordinate(5, 5), new Area(0, 1))
     );

--- a/tests/Unit/GameFireShotTest.php
+++ b/tests/Unit/GameFireShotTest.php
@@ -8,7 +8,6 @@ use App\Domain\Game\Coordinate;
 use App\Domain\Game\Game;
 use Tests\Support\FleetFactory;
 
-
 it('miss / hit / sunk oraz blokada duplikatów', function () {
     $game = Game::create(new ClassicRuleset(new BoardSize(10, 10)));
     $game->placeFleet(FleetFactory::classic10x10()); // ← najważniejsze: pełna, poprawna flota

--- a/tests/Unit/GameFireTorpedoTest.php
+++ b/tests/Unit/GameFireTorpedoTest.php
@@ -1,13 +1,12 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Unit;
 
-use App\Domain\Game\FunRuleset;
 use App\Domain\Game\Coordinate;
 use App\Domain\Game\Direction;
+use App\Domain\Game\FunRuleset;
 use App\Domain\Game\Game;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FleetFactory;

--- a/tests/Unit/GameSonarPingTest.php
+++ b/tests/Unit/GameSonarPingTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Tests\Unit;
@@ -24,7 +23,7 @@ final class GameSonarPingTest extends TestCase
         // Map to quick lookup
         $byKey = [];
         foreach ($results as $r) {
-            $byKey[$r['x'] . ':' . $r['y']] = (bool)$r['occupied'];
+            $byKey[$r['x'].':'.$r['y']] = (bool) $r['occupied'];
         }
 
         // Only in-bounds cells from (0,0) with radius=3 (cross)

--- a/tests/Unit/MapperSnapshotTest.php
+++ b/tests/Unit/MapperSnapshotTest.php
@@ -37,4 +37,4 @@ it('mapuje Game -> array -> Game (round-trip) z flotą', function () {
     expect($g2->fleet())->not->toBeNull();
 });
 
-//test
+// test


### PR DESCRIPTION
Closes #11

## Zakres (3 commity)

1. **Refactor**: usunięte martwe `method_exists()` na klasie `Game` (11 findings PHPStan) — w mapperze ciągnęły za sobą nieosiągalne reflection-fallbacki i martwe `cellsFor()`; przy okazji `Route` z `Attribute` zamiast deprecated `Annotation` w `GameQueryController`
2. **Style**: `php-cs-fixer` na całym repo (32 pliki, mechaniczne @Symfony) — warunek zielonego kroku dry-run w CI
3. **Chore**: `phpstan.neon` (level 5, `src`; wąski ignore `property.onlyWritten` dla encji Doctrine — timestampy pisze ORM) + nowy job **static-analysis** w CI (PHPStan + php-cs-fixer --dry-run) + sprzątnięcie workflow z kroków debug (ping/nslookup/echo DSN, martwy patch phpunit.xml) + `make stan` bez `|| true`

`tests/` poza analizą PHPStan: testy pisane w Pest (closures) generują fałszywe "assert outside class scope" bez dedykowanego rozszerzenia — do rozważenia osobno.

## Weryfikacja

- `phpstan analyze`: **No errors**
- `php-cs-fixer --dry-run`: **0 plików do poprawy**
- Pełny Pest w Dockerze: **59 passed, 1166 assertions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)