### PR TITLE
Fix frontend type errors: unwrap composable refs in Game.vue

### DIFF
--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -1,37 +1,41 @@
 <script setup lang="ts">
 import GameGameBoard from './GameBoard.vue';
 import { useGame } from '../composables/useGame';
-import { computed, unref } from 'vue'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 
-const g = useGame();
+// Destrukturyzacja: ref-y stają się top-level, więc template odpakowuje je
+// automatycznie (zagnieżdżone w zwykłym obiekcie NIE są odpakowywane).
+const {
+    status, finished, turn, loading, error, disabled, shot,
+    shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
+    toast, toastType,
+    playerGrid, playerUnderFireOverlay, enemyFogGrid, lastShot, sunkCells,
+} = useGame();
 const router = useRouter();
 
 // Połącz siatkę gracza z overlayem strzałów przeciwnika (opp-hit/opp-miss)
-const mergedPlayerGrid = computed(() => {
-    const base = unref(g.playerGrid) as unknown as string[][];
-    const ov = unref(g.playerUnderFireOverlay) as unknown as (('none'|'opp-hit'|'opp-miss')[])[];
-    if (!Array.isArray(base) || !Array.isArray(ov) || base.length !== ov.length) return base as any;
+const mergedPlayerGrid = computed<string[][]>(() => {
+    const base = playerGrid.value;
+    const ov = playerUnderFireOverlay.value;
+    if (base.length !== ov.length) return base;
     return base.map((row, y) => row.map((cell, x) => {
-        const o = ov?.[y]?.[x] ?? 'none';
+        const o = ov[y]?.[x] ?? 'none';
         if (o === 'none') return cell as string;
         // złącz klasy, aby widoczny był statek i overlay
         return `${cell} ${o}`.trim();
     }));
 });
 
-const enemyAnimatedGrid = computed(() => {
-    const base = unref(g.enemyFogGrid) as unknown as string[][];
-    const ls = unref(g.lastShot) as { x: number; y: number; result: string } | null;
-    const sunk = unref(g.sunkCells) as Array<[number, number]> | null | undefined;
+const enemyAnimatedGrid = computed<string[][]>(() => {
+    const ls = lastShot.value;
+    const sunk = sunkCells.value;
 
-    if (!Array.isArray(base)) return base as any;
-
-    return base.map((row, y) => row.map((cell, x) => {
-        let classes = cell as string;
+    return enemyFogGrid.value.map((row, y) => row.map((cell, x) => {
+        let classes: string = cell;
 
         // Zatopione statki – stała klasa 'sink'
-        if (Array.isArray(sunk) && sunk.some(([sx, sy]) => sx === x && sy === y)) {
+        if (sunk.some(([sx, sy]) => sx === x && sy === y)) {
             classes += ' sink';
         }
 
@@ -48,17 +52,9 @@ const enemyAnimatedGrid = computed(() => {
     }));
 });
 
-
-
 function handleShot(x: number, y: number) {
-    // Uwaga: w <script setup> wartości z composable nie są auto‑odwijane poza template
-    // więc g.disabled jest Ref<boolean>. Sprawdźmy .value.
-    if (g.disabled && 'value' in g.disabled) {
-        if (!g.disabled.value) g.shot(x, y);
-    } else {
-        // fallback – jeśli z jakiegoś powodu disabled nie jest Refem
-        // to i tak spróbujemy oddać strzał
-        g.shot(x, y);
+    if (!disabled.value) {
+        shot(x, y);
     }
 }
 
@@ -69,8 +65,8 @@ function newGame() {
 
 <template>
     <!-- Banner końca gry u góry sekcji -->
-    <div v-if="g.finished || g.status === 'won' || g.status === 'lost'" class="game-banner" :class="g.status">
-        Koniec gry: {{ g.status === 'won' ? 'Wygrana' : 'Przegrana' }}
+    <div v-if="finished || status === 'won' || status === 'lost'" class="game-banner" :class="status">
+        Koniec gry: {{ status === 'won' ? 'Wygrana' : 'Przegrana' }}
         <button class="btn small" @click="newGame">Nowa gra</button>
     </div>
 
@@ -83,17 +79,17 @@ function newGame() {
 
         <div>
             <h3>Przeciwnik</h3>
-            <GameGameBoard :grid="enemyAnimatedGrid" :onCellClick="handleShot" :disabled="g.disabled" />
-            <div v-if="g.loading">Ładowanie…</div>
-            <div v-if="g.error" style="color:crimson">{{ g.error }}</div>
+            <GameGameBoard :grid="enemyAnimatedGrid" :onCellClick="handleShot" :disabled="disabled" />
+            <div v-if="loading">Ładowanie…</div>
+            <div v-if="error" style="color:crimson">{{ error }}</div>
             <div class="hud">
-                <div>Ruch: <strong>{{ g.turn }}</strong> <span v-if="g.disabled">(zablokowane)</span></div>
+                <div>Ruch: <strong>{{ turn }}</strong> <span v-if="disabled">(zablokowane)</span></div>
                 <div class="stats">
-                    <span class="pill">Strzały: <strong>{{ g.shotsCount }}</strong></span>
-                    <span class="pill hit">Trafienia: <strong>{{ g.hitsCount }}</strong></span>
-                    <span class="pill miss">Pudła: <strong>{{ g.missesCount }}</strong></span>
-                    <span class="pill dup">Duplikaty: <strong>{{ g.duplicatesCount }}</strong></span>
-                    <span class="pill opp">Trafienia przeciwnika: <strong>{{ g.opponentHitsCount }}</strong></span>
+                    <span class="pill">Strzały: <strong>{{ shotsCount }}</strong></span>
+                    <span class="pill hit">Trafienia: <strong>{{ hitsCount }}</strong></span>
+                    <span class="pill miss">Pudła: <strong>{{ missesCount }}</strong></span>
+                    <span class="pill dup">Duplikaty: <strong>{{ duplicatesCount }}</strong></span>
+                    <span class="pill opp">Trafienia przeciwnika: <strong>{{ opponentHitsCount }}</strong></span>
                 </div>
                 <div class="legend">
                     <span class="item"><span class="box ship"></span> Statek (Twoja plansza)</span>
@@ -102,7 +98,7 @@ function newGame() {
                     <span class="item"><span class="box opp-hit"></span> Trafienie przeciwnika</span>
                     <span class="item"><span class="box opp-miss"></span> Pudło przeciwnika</span>
                 </div>
-                <div v-if="g.toast" class="toast" :class="g.toastType">{{ g.toast }}</div>
+                <div v-if="toast" class="toast" :class="toastType">{{ toast }}</div>
             </div>
         </div>
     </div>

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -2,15 +2,19 @@ import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { getGame, fireShot, type GameViewDTO, type ShotResultDTO } from '../api/gameApi.ts';
 
+export type PlayerCell = 'empty'|'ship'|'hit'|'miss';
+export type EnemyCell = 'empty'|'hit'|'miss';
+export type OverlayCell = 'none'|'opp-hit'|'opp-miss';
+
 export function useGame() {
     const route = useRoute();
     const gameId = ref<string>(String(route.params.id ?? ''));
     const width = ref<number>(10);
     const height = ref<number>(10);
-    const playerGrid = ref<Array<Array<'empty'|'ship'|'hit'|'miss'>>>([]);
+    const playerGrid = ref<PlayerCell[][]>([]);
     // Overlay trafień/pudeł przeciwnika na planszy gracza
-    const playerUnderFireOverlay = ref<Array<Array<'none'|'opp-hit'|'opp-miss'>>>([]);
-    const enemyFogGrid = ref<Array<Array<'empty'|'hit'|'miss'>>>([]);
+    const playerUnderFireOverlay = ref<OverlayCell[][]>([]);
+    const enemyFogGrid = ref<EnemyCell[][]>([]);
     const turn = ref<GameViewDTO['turn']>('player');
     const status = ref<GameViewDTO['status']>('pending');
     const finished = ref<boolean>(false);
@@ -25,7 +29,7 @@ export function useGame() {
     const sunkCells = ref<Array<[number, number]>>([]);
 
 
-    function buildEmptyGrid(w: number, h: number, fill: 'empty'|'miss'|'hit'|'ship' = 'empty') {
+    function buildEmptyGrid<T extends string>(w: number, h: number, fill: T): T[][] {
         return Array.from({ length: h }, () => Array.from({ length: w }, () => fill));
     }
 
@@ -33,7 +37,7 @@ export function useGame() {
         width.value = dto.board.w;
         height.value = dto.board.h;
         // player grid with ships
-        const pg = buildEmptyGrid(dto.board.w, dto.board.h, 'empty');
+        const pg = buildEmptyGrid<PlayerCell>(dto.board.w, dto.board.h, 'empty');
         for (const s of dto.playerFleet) {
             const o = (s.o as unknown as string).toLowerCase() as 'h'|'v';
             for (let i = 0; i < s.l; i++) {
@@ -45,7 +49,7 @@ export function useGame() {
         playerGrid.value = pg;
 
         // overlay trafień/pudeł przeciwnika na planszy gracza
-        const ov = Array.from({ length: dto.board.h }, () => Array.from({ length: dto.board.w }, () => 'none' as 'none'|'opp-hit'|'opp-miss'));
+        const ov = buildEmptyGrid<OverlayCell>(dto.board.w, dto.board.h, 'none');
         if (dto.playerUnderFireGrid) {
             for (const [x,y] of dto.playerUnderFireGrid.hits) {
                 if (ov[y] && typeof ov[y][x] !== 'undefined') ov[y][x] = 'opp-hit';
@@ -57,7 +61,7 @@ export function useGame() {
         playerUnderFireOverlay.value = ov;
 
         // enemy fog grid from hits/misses/sunk
-        const eg = buildEmptyGrid(dto.board.w, dto.board.h, 'empty');
+        const eg = buildEmptyGrid<EnemyCell>(dto.board.w, dto.board.h, 'empty');
         const sunk: Array<[number, number]> = [];
 
         for (const [x, y] of dto.enemyFogGrid.hits) {


### PR DESCRIPTION
Closes #17

## Problem

`npm run build` (vue-tsc) padał na dwóch klasach błędów — i drugi z nich okazał się realnym bugiem UI:

1. **`Game.vue`**: `useGame()` zwraca zwykły obiekt z Ref-ami, a Vue odpakowuje w template wyłącznie ref-y najwyższego poziomu. `g.finished` (Ref — obiekt, zawsze truthy) sprawiał, że **baner „Koniec gry" renderował się od startu rozgrywki**, a porównania `g.status === 'won'` były zawsze fałszywe (stąd zawsze „Przegrana").
2. **`useGame.ts`**: `buildEmptyGrid()` zwracał szeroką unię komórek przypisywaną do węższego typu `enemyFogGrid`.

## Zmiany

- `Game.vue`: destrukturyzacja ref-ów z `useGame()` na top-level + czysty template; znikają casty `as unknown as` i obejście `'value' in g.disabled`
- `useGame.ts`: `buildEmptyGrid<T>` jako generyk, eksport typów `PlayerCell`/`EnemyCell`/`OverlayCell`

## Weryfikacja

- `npm run build` (vue-tsc + vite): **przechodzi**
- Runtime w przeglądarce (backend dev, pełny flow utworzenie gry → rozstawienie floty → strzały): baner **nie** renderuje się na starcie, HUD poprawnie liczy strzały/trafienia/pudła, overlay strzałów AI na planszy gracza działa, konsola bez błędów
- Baner na koniec gry: warunek identyczny, tylko na odpakowanych wartościach (`finished`/`status` z API są pokryte testami funkcjonalnymi backendu); dogranie pełnej partii z losową flotą pominięte

🤖 Generated with [Claude Code](https://claude.com/claude-code)