### PR TITLE
Fun mode: ruleset selection, weapon limits and special weapons UI

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -10,10 +10,21 @@ export interface EnemyFogGridView {
 
 export interface PlayerFleetItem { x: number; y: number; o: 'h' | 'v'; l: number }
 
+export type RulesetName = 'classic' | 'fun';
+
+export interface WeaponState { used: number; limit: number }
+export interface WeaponsState {
+    torpedo: WeaponState;
+    sonar: WeaponState;
+    airRaid: WeaponState;
+}
+
 export interface GameViewDTO {
     id: string;
     status: 'pending' | 'in_progress' | 'won' | 'lost';
     board: { w: number; h: number };
+    ruleset: RulesetName;
+    weapons: WeaponsState;
     mode: 'standard' | 'nonstandard' | string;
     opponent: 'mock' | 'ai' | 'pvp' | string;
     turn: 'player' | 'opponent' | 'none';
@@ -31,6 +42,7 @@ export interface GameViewDTO {
 export interface CreateGameResponse {
     id: string;
     status: string;
+    ruleset: RulesetName;
     board: { w: number; h: number };
 }
 
@@ -43,9 +55,9 @@ export interface ShotResultDTO {
     opponentMoves: { x: number; y: number; result: 'hit' | 'miss' | 'sunk' | 'duplicate' }[];
 }
 
-export async function createGame(): Promise<CreateGameResponse> {
-    // backend przyjmuje puste body (opcjonalne width/height)
-    return http.post<CreateGameResponse>('/games', {});
+export async function createGame(mode: RulesetName = 'classic'): Promise<CreateGameResponse> {
+    // backend przyjmuje opcjonalne width/height/mode
+    return http.post<CreateGameResponse>('/games', { mode });
 }
 
 export async function getGame(id: string): Promise<GameViewDTO> {
@@ -59,4 +71,42 @@ export async function placeFleet(id: string, ships: PlayerFleetItem[]): Promise<
 
 export async function fireShot(id: string, x: number, y: number): Promise<ShotResultDTO> {
     return http.post<ShotResultDTO>(`/games/${id}/shots`, { x, y });
+}
+
+// --- bronie specjalne (tryb fun) ---
+
+export type TorpedoDirection = 'N' | 'E' | 'S' | 'W';
+
+export interface CellShotResult { x: number; y: number; result: 'hit' | 'miss' | 'sunk' | 'duplicate' }
+
+export interface TurnOutcomeDTO {
+    finished: boolean;
+    win: boolean;
+    loss: boolean;
+    turn: 'player' | 'opponent' | 'none';
+    opponentMoves: CellShotResult[];
+}
+
+export interface WeaponShotsResponse extends TurnOutcomeDTO {
+    results: CellShotResult[];
+}
+
+export interface SonarCell { x: number; y: number; occupied: boolean }
+export interface SonarResponse {
+    results: SonarCell[];
+    shape: string;
+    radius: number;
+}
+
+export async function fireTorpedo(id: string, x: number, y: number, direction: TorpedoDirection): Promise<WeaponShotsResponse> {
+    return http.post<WeaponShotsResponse>(`/games/${id}/torpedo`, { x, y, direction });
+}
+
+export async function sonarPing(id: string, x: number, y: number): Promise<SonarResponse> {
+    return http.post<SonarResponse>(`/games/${id}/sonar`, { x, y });
+}
+
+export async function sendAirRaid(id: string, x: number, y: number): Promise<WeaponShotsResponse> {
+    // pół-zasięgi 1×1 → obszar 3×3 (maksimum dozwolone przez FunRuleset)
+    return http.post<WeaponShotsResponse>(`/games/${id}/air-raid`, { x, y, width: 1, height: 1 });
 }

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -7,7 +7,8 @@ import { useRouter } from 'vue-router'
 // Destrukturyzacja: ref-y stają się top-level, więc template odpakowuje je
 // automatycznie (zagnieżdżone w zwykłym obiekcie NIE są odpakowywane).
 const {
-    status, finished, turn, loading, error, disabled, shot,
+    status, finished, turn, loading, error, disabled, attack,
+    ruleset, weapons, weaponMode, torpedoDirection, sonarMarks,
     shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
     toast, toastType,
     playerGrid, playerUnderFireOverlay, enemyFogGrid, lastShot, sunkCells,
@@ -30,9 +31,15 @@ const mergedPlayerGrid = computed<string[][]>(() => {
 const enemyAnimatedGrid = computed<string[][]>(() => {
     const ls = lastShot.value;
     const sunk = sunkCells.value;
+    const sonar = new Map(sonarMarks.value.map(c => [`${c.x}:${c.y}`, c.occupied]));
 
     return enemyFogGrid.value.map((row, y) => row.map((cell, x) => {
         let classes: string = cell;
+
+        // Skan sonaru — tylko na polach jeszcze nieostrzelanych
+        if (cell === 'empty' && sonar.has(`${x}:${y}`)) {
+            classes += sonar.get(`${x}:${y}`) ? ' sonar-ship' : ' sonar-water';
+        }
 
         // Zatopione statki – stała klasa 'sink'
         if (sunk.some(([sx, sy]) => sx === x && sy === y)) {
@@ -54,9 +61,22 @@ const enemyAnimatedGrid = computed<string[][]>(() => {
 
 function handleShot(x: number, y: number) {
     if (!disabled.value) {
-        shot(x, y);
+        attack(x, y);
     }
 }
+
+function selectWeapon(mode: 'shot' | 'torpedo' | 'sonar' | 'airraid') {
+    weaponMode.value = mode;
+}
+
+const weaponHint = computed(() => {
+    switch (weaponMode.value) {
+        case 'torpedo': return 'Kliknij pole startowe torpedy — popłynie w wybranym kierunku do krawędzi.';
+        case 'sonar': return 'Kliknij centrum skanu — sonar sprawdzi krzyż o promieniu 3.';
+        case 'airraid': return 'Kliknij centrum nalotu — ostrzał obszaru 3×3.';
+        default: return '';
+    }
+});
 
 function newGame() {
     router.push({ name: 'home' })
@@ -80,6 +100,37 @@ function newGame() {
         <div>
             <h3>Przeciwnik</h3>
             <GameGameBoard :grid="enemyAnimatedGrid" :onCellClick="handleShot" :disabled="disabled" />
+
+            <!-- Panel broni specjalnych (tylko tryb fun) -->
+            <div v-if="ruleset === 'fun' && weapons" class="weapons">
+                <button class="wbtn" :class="{ active: weaponMode === 'shot' }" @click="selectWeapon('shot')">
+                    🎯 Strzał
+                </button>
+                <button class="wbtn" :class="{ active: weaponMode === 'torpedo' }"
+                        :disabled="weapons.torpedo.used >= weapons.torpedo.limit"
+                        @click="selectWeapon('torpedo')">
+                    🚀 Torpeda {{ weapons.torpedo.limit - weapons.torpedo.used }}/{{ weapons.torpedo.limit }}
+                </button>
+                <button class="wbtn" :class="{ active: weaponMode === 'sonar' }"
+                        :disabled="weapons.sonar.used >= weapons.sonar.limit"
+                        @click="selectWeapon('sonar')">
+                    📡 Sonar {{ weapons.sonar.limit - weapons.sonar.used }}/{{ weapons.sonar.limit }}
+                </button>
+                <button class="wbtn" :class="{ active: weaponMode === 'airraid' }"
+                        :disabled="weapons.airRaid.used >= weapons.airRaid.limit"
+                        @click="selectWeapon('airraid')">
+                    ✈️ Nalot {{ weapons.airRaid.limit - weapons.airRaid.used }}/{{ weapons.airRaid.limit }}
+                </button>
+            </div>
+            <div v-if="ruleset === 'fun' && weaponMode === 'torpedo'" class="weapon-opts">
+                Kierunek:
+                <label><input type="radio" value="N" v-model="torpedoDirection" /> ↑ N</label>
+                <label><input type="radio" value="E" v-model="torpedoDirection" /> → E</label>
+                <label><input type="radio" value="S" v-model="torpedoDirection" /> ↓ S</label>
+                <label><input type="radio" value="W" v-model="torpedoDirection" /> ← W</label>
+            </div>
+            <div v-if="weaponHint" class="weapon-hint">{{ weaponHint }}</div>
+
             <div v-if="loading">Ładowanie…</div>
             <div v-if="error" style="color:crimson">{{ error }}</div>
             <div class="hud">
@@ -97,6 +148,10 @@ function newGame() {
                     <span class="item"><span class="box miss"></span> Pudło</span>
                     <span class="item"><span class="box opp-hit"></span> Trafienie przeciwnika</span>
                     <span class="item"><span class="box opp-miss"></span> Pudło przeciwnika</span>
+                    <template v-if="ruleset === 'fun'">
+                        <span class="item"><span class="box sonar-ship"></span> Sonar: statek</span>
+                        <span class="item"><span class="box sonar-water"></span> Sonar: woda</span>
+                    </template>
                 </div>
                 <div v-if="toast" class="toast" :class="toastType">{{ toast }}</div>
             </div>
@@ -130,6 +185,14 @@ function newGame() {
 .legend .box.miss { background:#bfdbfe; border-color:#bfdbfe; }
 .legend .box.opp-hit { background: transparent; border-color:#7a0a0a; box-shadow: inset 0 0 0 2px #7a0a0a; }
 .legend .box.opp-miss { background: transparent; border-color:#0c4a6e; box-shadow: inset 0 0 0 2px #0c4a6e; }
+.legend .box.sonar-ship { background: #fef3c7; border-color:#d97706; box-shadow: inset 0 0 0 2px #d97706; }
+.legend .box.sonar-water { background: #f0f9ff; border-color:#7dd3fc; }
+.weapons { display:flex; gap:.4rem; margin-top:.6rem; flex-wrap:wrap; }
+.wbtn { padding:.3rem .6rem; border:1px solid #cbd5e1; border-radius:6px; background:#f8fafc; cursor:pointer; }
+.wbtn.active { background:#1f6feb; color:#fff; border-color:#1f6feb; }
+.wbtn[disabled] { opacity:.45; cursor:not-allowed; }
+.weapon-opts { margin-top:.35rem; display:flex; gap:.6rem; align-items:center; color:#334155; }
+.weapon-hint { margin-top:.3rem; font-size:.9rem; color:#475569; }
 .toast { display:inline-block; padding:.3rem .6rem; border-radius:6px; border:1px solid #cbd5e1; background:#f8fafc; color:#0f172a; }
 .toast.warn { background:#fff7ed; border-color:#fed7aa; color:#7c2d12; }
 .toast.error { background:#fee2e2; border-color:#fecaca; color:#7f1d1d; }

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -83,6 +83,17 @@ function handleClick(x: number, y: number) {
     background: lightblue;
 }
 
+/* Skan sonaru (tryb fun, plansza przeciwnika) */
+.cell.sonar-ship {
+    background: #fef3c7;
+    box-shadow: inset 0 0 0 2px #d97706;
+}
+
+.cell.sonar-water {
+    background: #f0f9ff;
+    background-image: radial-gradient(circle at 50% 50%, rgba(125, 211, 252, 0.6) 20%, transparent 21%);
+}
+
 /* Overlay trafień/pudeł przeciwnika (na planszy gracza) */
 .cell.opp-hit {
     position: relative;

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -1,6 +1,12 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
-import { getGame, fireShot, type GameViewDTO, type ShotResultDTO } from '../api/gameApi.ts';
+import {
+    getGame, fireShot, fireTorpedo, sonarPing, sendAirRaid,
+    type GameViewDTO, type ShotResultDTO, type RulesetName, type WeaponsState,
+    type TorpedoDirection, type TurnOutcomeDTO, type SonarCell,
+} from '../api/gameApi.ts';
+
+export type WeaponMode = 'shot' | 'torpedo' | 'sonar' | 'airraid';
 
 export type PlayerCell = 'empty'|'ship'|'hit'|'miss';
 export type EnemyCell = 'empty'|'hit'|'miss';
@@ -27,6 +33,14 @@ export function useGame() {
     // NOWE:
     const lastShot = ref<{ x: number; y: number; result: ShotResultDTO['result'] } | null>(null);
     const sunkCells = ref<Array<[number, number]>>([]);
+
+    // Tryb fun: bronie specjalne
+    const ruleset = ref<RulesetName>('classic');
+    const weapons = ref<WeaponsState | null>(null);
+    const weaponMode = ref<WeaponMode>('shot');
+    const torpedoDirection = ref<TorpedoDirection>('E');
+    // Wyniki sonaru — tylko po stronie klienta (backend nie zapisuje skanów)
+    const sonarMarks = ref<SonarCell[]>([]);
 
 
     function buildEmptyGrid<T extends string>(w: number, h: number, fill: T): T[][] {
@@ -86,6 +100,21 @@ export function useGame() {
         turn.value = dto.turn;
         status.value = dto.status;
         finished.value = dto.finished;
+        ruleset.value = dto.ruleset ?? 'classic';
+        weapons.value = dto.weapons ?? null;
+    }
+
+    function applyTurnOutcome(o: TurnOutcomeDTO) {
+        turn.value = o.turn;
+        if (o.finished) {
+            status.value = o.win ? 'won' : (o.loss ? 'lost' : status.value);
+            finished.value = true;
+        }
+    }
+
+    function canAct(): boolean {
+        return !!gameId.value && turn.value === 'player' && !shooting.value
+            && status.value !== 'won' && status.value !== 'lost';
     }
 
     async function start() {
@@ -163,6 +192,64 @@ export function useGame() {
         }
     }
 
+    async function torpedoAt(x: number, y: number) {
+        if (!canAct()) return;
+        try {
+            shooting.value = true;
+            const res = await fireTorpedo(gameId.value, x, y, torpedoDirection.value);
+            applyTurnOutcome(res);
+            await refresh();
+        } catch (e: any) {
+            showToast(e?.message ?? 'Torpeda nie wypaliła', 'warn', 2500);
+        } finally {
+            shooting.value = false;
+            weaponMode.value = 'shot';
+        }
+    }
+
+    async function sonarAt(x: number, y: number) {
+        if (!canAct()) return;
+        try {
+            shooting.value = true;
+            const res = await sonarPing(gameId.value, x, y);
+            // dopisz skan (nadpisując wcześniejsze wpisy dla tych samych pól)
+            const merged = new Map(sonarMarks.value.map(c => [`${c.x}:${c.y}`, c]));
+            for (const c of res.results) merged.set(`${c.x}:${c.y}`, c);
+            sonarMarks.value = [...merged.values()];
+            await refresh(); // licznik użyć
+        } catch (e: any) {
+            showToast(e?.message ?? 'Sonar nie zadziałał', 'warn', 2500);
+        } finally {
+            shooting.value = false;
+            weaponMode.value = 'shot';
+        }
+    }
+
+    async function airRaidAt(x: number, y: number) {
+        if (!canAct()) return;
+        try {
+            shooting.value = true;
+            const res = await sendAirRaid(gameId.value, x, y);
+            applyTurnOutcome(res);
+            await refresh();
+        } catch (e: any) {
+            showToast(e?.message ?? 'Nalot się nie powiódł', 'warn', 2500);
+        } finally {
+            shooting.value = false;
+            weaponMode.value = 'shot';
+        }
+    }
+
+    /** Jeden punkt wejścia dla kliknięcia w planszę przeciwnika — wg aktywnego trybu. */
+    async function attack(x: number, y: number) {
+        switch (weaponMode.value) {
+            case 'torpedo': return torpedoAt(x, y);
+            case 'sonar': return sonarAt(x, y);
+            case 'airraid': return airRaidAt(x, y);
+            default: return shot(x, y);
+        }
+    }
+
     onMounted(start);
 
     const size = computed(() => Math.max(width.value, height.value));
@@ -191,7 +278,9 @@ export function useGame() {
 
     return {
         gameId, size, playerGrid, playerUnderFireOverlay, enemyFogGrid, turn, status, finished,
-        loading, error, start, refresh, shot, disabled,
+        loading, error, start, refresh, shot, attack, disabled,
+        // tryb fun
+        ruleset, weapons, weaponMode, torpedoDirection, sonarMarks,
         // stats
         shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
         // toast

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -3,6 +3,18 @@
         <h1>Witaj w grze</h1>
         <p>Rozpocznij nową rozgrywkę.</p>
 
+        <fieldset class="mode">
+            <legend>Wariant zasad</legend>
+            <label>
+                <input type="radio" value="classic" v-model="mode" />
+                Klasyczny — tylko pojedyncze strzały
+            </label>
+            <label>
+                <input type="radio" value="fun" v-model="mode" />
+                Fun — bronie specjalne: 🚀 torpeda ×2, 📡 sonar ×3, ✈️ nalot ×1
+            </label>
+        </fieldset>
+
         <button class="btn" :disabled="loading" @click="onNewGame">
             {{ loading ? 'Tworzenie…' : 'Nowa gra' }}
         </button>
@@ -14,17 +26,18 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { createGame } from '../api/gameApi'
+import { createGame, type RulesetName } from '../api/gameApi'
 
 const router = useRouter()
 const loading = ref(false)
 const error = ref('')
+const mode = ref<RulesetName>('classic')
 
 async function onNewGame() {
   loading.value = true
   error.value = ''
   try {
-    const g = await createGame()
+    const g = await createGame(mode.value)
     await router.push({ name: 'place-fleet', params: { id: g.id } })
   } catch (e: any) {
     error.value = e?.message ?? 'Nie udało się utworzyć gry'
@@ -36,6 +49,9 @@ async function onNewGame() {
 
 <style scoped>
 h1 { margin-bottom: 0.5rem; }
+.mode { margin: 0.75rem 0 1rem; padding: 0.5rem 0.75rem; border: 1px solid #cbd5e1; border-radius: 6px; display: inline-flex; flex-direction: column; gap: 0.35rem; }
+.mode legend { padding: 0 0.3rem; color: #475569; font-size: 0.9rem; }
+.mode label { cursor: pointer; }
 .btn { padding: 0.5rem 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
 .btn[disabled] { opacity: 0.7; cursor: default; }
 .err { color: crimson; margin-top: 0.5rem; }

--- a/src/Application/Game/CreateGame.php
+++ b/src/Application/Game/CreateGame.php
@@ -4,6 +4,7 @@ namespace App\Application\Game;
 
 use App\Domain\Game\BoardSize;
 use App\Domain\Game\ClassicRuleset;
+use App\Domain\Game\FunRuleset;
 use App\Domain\Game\Game;
 use App\Domain\Game\GameRepository;
 
@@ -13,9 +14,11 @@ final class CreateGame
     {
     }
 
-    public function handle(?int $w = null, ?int $h = null): Game
+    public function handle(?int $w = null, ?int $h = null, string $mode = 'classic'): Game
     {
-        $rules = new ClassicRuleset(new BoardSize($w ?? 10, $h ?? 10));
+        $size = new BoardSize($w ?? 10, $h ?? 10);
+        $rules = 'fun' === $mode ? new FunRuleset($size) : new ClassicRuleset($size);
+
         $game = Game::create($rules);
         $this->repo->save($game);
 

--- a/src/Application/Game/FireShot.php
+++ b/src/Application/Game/FireShot.php
@@ -2,20 +2,19 @@
 
 namespace App\Application\Game;
 
-use App\Domain\Game\AI\HuntTargetAI;
 use App\Domain\Game\Coordinate;
 use App\Domain\Game\GameRepository;
 use App\Domain\Shared\GameId;
 
 final class FireShot
 {
-    public function __construct(private readonly GameRepository $repo)
-    {
+    public function __construct(
+        private readonly GameRepository $repo,
+        private readonly OpponentTurn $opponentTurn,
+    ) {
     }
 
     /**
-     * Rozszerzona odpowiedź Iteracja 1.
-     *
      * @return array{
      *   result:string,
      *   win:bool,
@@ -45,41 +44,10 @@ final class FireShot
 
         $out = $game->fireShot(new Coordinate($x, $y));
 
-        // Wyliczenia po ruchu gracza
-        $finished = $game->isFinished();
-        $win = 'won' === $game->status()->value;
-        $loss = 'lost' === $game->status()->value;
-
-        $opponentMoves = [];
-
-        // Przeciwnik (HuntTargetAI): 1 strzał synchronicznie, tylko gdy gra nie skończona
-        if (!$finished) {
-            $ai = HuntTargetAI::fromSnapshot($game->aiState());
-            $target = $ai->nextShot($game->opponentShotsView());
-            $oppResult = $game->fireOpponentShot($target);
-            $ai->notify($target, $oppResult);
-            $game->setAiState($ai->toSnapshot());
-            $opponentMoves[] = ['x' => $target->x, 'y' => $target->y, 'result' => $oppResult->value];
-
-            // Re-ewaluacja zakończenia po ruchu przeciwnika
-            $finished = 'lost' === $game->status()->value;
-            $win = 'won' === $game->status()->value;
-            $loss = 'lost' === $game->status()->value;
-        }
-
-        // Po ruchu przeciwnika tura wraca do gracza (o ile gra nie skończona)
-        $turn = $finished ? 'none' : 'player';
-        $game->setTurn($turn);
+        $turnOutcome = $this->opponentTurn->respond($game);
 
         $this->repo->save($game);
 
-        return [
-            'result' => $out->value,                     // 'miss' | 'hit' | 'sunk' | 'duplicate'
-            'win' => $win,
-            'loss' => $loss,
-            'finished' => $finished,
-            'turn' => $turn,
-            'opponentMoves' => $opponentMoves,
-        ];
+        return ['result' => $out->value] + $turnOutcome;
     }
 }

--- a/src/Application/Game/FireTorpedo.php
+++ b/src/Application/Game/FireTorpedo.php
@@ -9,12 +9,21 @@ use App\Domain\Shared\GameId;
 
 final class FireTorpedo
 {
-    public function __construct(private GameRepository $repo)
-    {
+    public function __construct(
+        private readonly GameRepository $repo,
+        private readonly OpponentTurn $opponentTurn,
+    ) {
     }
 
     /**
-     * @return list<array{x:int,y:int,result:string}>
+     * @return array{
+     *   results:list<array{x:int,y:int,result:string}>,
+     *   win:bool,
+     *   loss:bool,
+     *   finished:bool,
+     *   turn:string,
+     *   opponentMoves:list<array{x:int,y:int,result:string}>
+     * }
      */
     public function __invoke(string $gameId, int $x, int $y, Direction $direction): array
     {
@@ -23,10 +32,22 @@ final class FireTorpedo
             throw new \DomainException('Game not found');
         }
 
+        if ($game->isFinished()) {
+            throw new \DomainException('Game already finished');
+        }
+
+        if ('player' !== $game->turn()) {
+            throw new \DomainException('Not player turn');
+        }
+
+        $game->setTurn('opponent');
+
         $results = $game->fireTorpedo(new Coordinate($x, $y), $direction);
+
+        $turnOutcome = $this->opponentTurn->respond($game);
 
         $this->repo->save($game);
 
-        return $results;
+        return ['results' => $results] + $turnOutcome;
     }
 }

--- a/src/Application/Game/OpponentTurn.php
+++ b/src/Application/Game/OpponentTurn.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Application\Game;
+
+use App\Domain\Game\AI\HuntTargetAI;
+use App\Domain\Game\Game;
+
+/**
+ * Odpowiedź przeciwnika (AI) po ofensywnym ruchu gracza: jeden strzał
+ * + rozliczenie tury i końca gry. Wspólne dla strzału, torpedy i nalotu.
+ */
+final class OpponentTurn
+{
+    /**
+     * @return array{finished:bool, win:bool, loss:bool, turn:string, opponentMoves:list<array{x:int,y:int,result:string}>}
+     */
+    public function respond(Game $game): array
+    {
+        $finished = $game->isFinished();
+        $opponentMoves = [];
+
+        if (!$finished) {
+            $ai = HuntTargetAI::fromSnapshot($game->aiState());
+            $target = $ai->nextShot($game->opponentShotsView());
+            $result = $game->fireOpponentShot($target);
+            $ai->notify($target, $result);
+            $game->setAiState($ai->toSnapshot());
+            $opponentMoves[] = ['x' => $target->x, 'y' => $target->y, 'result' => $result->value];
+
+            $finished = $game->isFinished();
+        }
+
+        // Po ruchu przeciwnika tura wraca do gracza (o ile gra nie skończona)
+        $turn = $finished ? 'none' : 'player';
+        $game->setTurn($turn);
+
+        return [
+            'finished' => $finished,
+            'win' => 'won' === $game->status()->value,
+            'loss' => 'lost' === $game->status()->value,
+            'turn' => $turn,
+            'opponentMoves' => $opponentMoves,
+        ];
+    }
+}

--- a/src/Application/Game/SendAirRaid.php
+++ b/src/Application/Game/SendAirRaid.php
@@ -9,10 +9,22 @@ use App\Domain\Shared\GameId;
 
 final class SendAirRaid
 {
-    public function __construct(private GameRepository $repo)
-    {
+    public function __construct(
+        private readonly GameRepository $repo,
+        private readonly OpponentTurn $opponentTurn,
+    ) {
     }
 
+    /**
+     * @return array{
+     *   results:list<array{x:int,y:int,result:string}>,
+     *   win:bool,
+     *   loss:bool,
+     *   finished:bool,
+     *   turn:string,
+     *   opponentMoves:list<array{x:int,y:int,result:string}>
+     * }
+     */
     public function __invoke(string $gameId, int $x, int $y, int $width, int $height): array
     {
         $game = $this->repo->get(new GameId($gameId));
@@ -20,11 +32,23 @@ final class SendAirRaid
             throw new \DomainException('Game not found');
         }
 
+        if ($game->isFinished()) {
+            throw new \DomainException('Game already finished');
+        }
+
+        if ('player' !== $game->turn()) {
+            throw new \DomainException('Not player turn');
+        }
+
+        $game->setTurn('opponent');
+
         $centralPoint = new Coordinate($x, $y);
         $results = $game->sendAirRaid($centralPoint, new Area($width, $height));
 
+        $turnOutcome = $this->opponentTurn->respond($game);
+
         $this->repo->save($game);
 
-        return $results;
+        return ['results' => $results] + $turnOutcome;
     }
 }

--- a/src/Domain/Game/ClassicRuleset.php
+++ b/src/Domain/Game/ClassicRuleset.php
@@ -8,6 +8,11 @@ final class ClassicRuleset implements Ruleset
     {
     }
 
+    public function name(): string
+    {
+        return 'classic';
+    }
+
     public function boardSize(): BoardSize
     {
         return $this->size;
@@ -24,8 +29,8 @@ final class ClassicRuleset implements Ruleset
         throw new \DomainException('Not accepted in classic ruleset');
     }
 
-    public function fireTorpedo(): bool
+    public function weaponLimits(): array
     {
-        throw new \DomainException('Not accepted in classic ruleset');
+        return ['torpedo' => 0, 'sonar' => 0, 'airRaid' => 0];
     }
 }

--- a/src/Domain/Game/FunRuleset.php
+++ b/src/Domain/Game/FunRuleset.php
@@ -8,6 +8,11 @@ final class FunRuleset implements Ruleset
     {
     }
 
+    public function name(): string
+    {
+        return 'fun';
+    }
+
     public function boardSize(): BoardSize
     {
         return $this->size;
@@ -23,8 +28,8 @@ final class FunRuleset implements Ruleset
         return new Area(3, 3);
     }
 
-    public function fireTorpedo(): bool
+    public function weaponLimits(): array
     {
-        return true;
+        return ['torpedo' => 2, 'sonar' => 3, 'airRaid' => 1];
     }
 }

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -27,6 +27,14 @@ final class Game
      */
     private array $aiState = [];
 
+    /**
+     * Liczba użyć broni specjalnych w tej grze (klucze: torpedo|sonar|airRaid).
+     * Limity per grę definiuje Ruleset::weaponLimits(); 0 = broń niedostępna.
+     *
+     * @var array<string,int>
+     */
+    private array $weaponUses = [];
+
     public function __construct(
         private GameId $id,
         private Ruleset $ruleset,
@@ -229,6 +237,53 @@ final class Game
         $this->aiState = $state;
     }
 
+    /**
+     * Stan broni specjalnych: użycia i limity z rulesetu.
+     *
+     * @return array<string, array{used:int, limit:int}>
+     */
+    public function weaponsState(): array
+    {
+        $out = [];
+        foreach ($this->ruleset->weaponLimits() as $weapon => $limit) {
+            $out[$weapon] = ['used' => $this->weaponUses[$weapon] ?? 0, 'limit' => $limit];
+        }
+
+        return $out;
+    }
+
+    /** @return array<string,int> surowe liczniki użyć (do snapshotu) */
+    public function weaponUses(): array
+    {
+        return $this->weaponUses;
+    }
+
+    /** @param array<string,int> $uses */
+    public function setWeaponUsesFromSnapshot(array $uses): void
+    {
+        $this->weaponUses = [];
+        foreach ($uses as $weapon => $count) {
+            $this->weaponUses[(string) $weapon] = max(0, (int) $count);
+        }
+    }
+
+    /**
+     * Zużywa jedno użycie broni; rzuca, gdy broń niedostępna w rulesecie
+     * albo limit na grę wyczerpany.
+     */
+    private function consumeWeapon(string $weapon): void
+    {
+        $limit = $this->ruleset->weaponLimits()[$weapon] ?? 0;
+        if ($limit <= 0) {
+            throw new \DomainException(sprintf('%s not available in this ruleset', ucfirst($weapon)));
+        }
+        $used = $this->weaponUses[$weapon] ?? 0;
+        if ($used >= $limit) {
+            throw new \DomainException(sprintf('%s limit reached', ucfirst($weapon)));
+        }
+        $this->weaponUses[$weapon] = $used + 1;
+    }
+
     /** Strzały gracza. @return list<array{x:int,y:int}> */
     public function shots(): array
     {
@@ -285,14 +340,14 @@ final class Game
             throw new \DomainException('Fleet not placed');
         }
 
-        $this->ruleset->fireTorpedo();
-
         $w = $this->ruleset->boardSize()->width;
         $h = $this->ruleset->boardSize()->height;
 
         if ($start->x >= $w || $start->y >= $h) {
             throw new \DomainException('Torpedo start outside board');
         }
+
+        $this->consumeWeapon('torpedo');
 
         // Direction vector
         [$dx, $dy] = match ($direction) {
@@ -329,6 +384,8 @@ final class Game
         if (!$this->playerSide->hasFleet()) {
             throw new \DomainException('Fleet not placed');
         }
+
+        $this->consumeWeapon('sonar');
 
         $target = $this->targetSide();
 
@@ -386,6 +443,8 @@ final class Game
         if (2 * $area->width + 1 > $max->width || 2 * $area->height + 1 > $max->height) {
             throw new \DomainException('Air Raid area is oversize');
         }
+
+        $this->consumeWeapon('airRaid');
 
         $fromX = max(0, $start->x - $area->width);
         $toX = min($w - 1, $start->x + $area->width);

--- a/src/Domain/Game/Ruleset.php
+++ b/src/Domain/Game/Ruleset.php
@@ -4,6 +4,9 @@ namespace App\Domain\Game;
 
 interface Ruleset
 {
+    /** Identyfikator wariantu zasad: 'classic' | 'fun' (do snapshotu i API). */
+    public function name(): string;
+
     public function boardSize(): BoardSize;
 
     /**
@@ -16,5 +19,10 @@ interface Ruleset
      */
     public function airRaidSize(): Area;
 
-    public function fireTorpedo(): bool;
+    /**
+     * Limity użyć broni specjalnych na grę; 0 = broń niedostępna w tym wariancie.
+     *
+     * @return array{torpedo:int, sonar:int, airRaid:int}
+     */
+    public function weaponLimits(): array;
 }

--- a/src/Infrastructure/Http/Controller/FireTorpedoController.php
+++ b/src/Infrastructure/Http/Controller/FireTorpedoController.php
@@ -50,10 +50,7 @@ final class FireTorpedoController
         }
 
         // DomainException zostanie zamienione na spójny JSON przez ExceptionSubscriber
-        $list = ($this->fireTorpedo)($id, $x, $y, $direction);
-
-        return new JsonResponse([
-            'results' => $list, // list of {x,y,result}
-        ]);
+        // results: list of {x,y,result} + win/loss/finished/turn/opponentMoves
+        return new JsonResponse(($this->fireTorpedo)($id, $x, $y, $direction));
     }
 }

--- a/src/Infrastructure/Http/Controller/GameController.php
+++ b/src/Infrastructure/Http/Controller/GameController.php
@@ -24,12 +24,18 @@ final class GameController
         $data = json_decode($req->getContent() ?: '{}', true) ?: [];
         $w = $data['width'] ?? null;
         $h = $data['height'] ?? null;
+        $mode = $data['mode'] ?? 'classic';
 
-        $game = $this->createGame->handle($w, $h);
+        if (!in_array($mode, ['classic', 'fun'], true)) {
+            throw new ApiException('Invalid mode: expected classic|fun', 'VALIDATION_ERROR', 400);
+        }
+
+        $game = $this->createGame->handle($w, $h, $mode);
 
         return new JsonResponse([
             'id' => (string) $game->id(),
             'status' => $game->status()->value,
+            'ruleset' => $game->ruleset()->name(),
             'board' => [
                 'w' => $game->ruleset()->boardSize()->width,
                 'h' => $game->ruleset()->boardSize()->height,

--- a/src/Infrastructure/Http/Controller/GameQueryController.php
+++ b/src/Infrastructure/Http/Controller/GameQueryController.php
@@ -88,6 +88,8 @@ final class GameQueryController
             'id' => (string) $game->id(),
             'status' => $game->status()->value,
             'board' => ['w' => $size->width, 'h' => $size->height],
+            'ruleset' => $game->ruleset()->name(),
+            'weapons' => $game->weaponsState(),
             'mode' => $game->mode(),
             'opponent' => $game->opponent(),
             'turn' => $turn,

--- a/src/Infrastructure/Http/Controller/SendAirRaidController.php
+++ b/src/Infrastructure/Http/Controller/SendAirRaidController.php
@@ -16,7 +16,7 @@ final class SendAirRaidController
     {
     }
 
-    #[Route('{id}/air-raid', name: 'api_games_air_raid', methods: ['POST'])]
+    #[Route('/{id}/air-raid', name: 'api_games_air_raid', methods: ['POST'])]
     public function __invoke(string $id, Request $request): JsonResponse
     {
         if (!Uuid::isValid($id)) {
@@ -38,10 +38,7 @@ final class SendAirRaidController
         }
 
         // DomainException zostanie obsłużony przez ExceptionSubscriber (422/400)
-        $list = ($this->sendAirRaid)($id, $x, $y, $width, $height);
-
-        return new JsonResponse([
-            'result' => $list, // list of {x,y,result?}
-        ]);
+        // results: list of {x,y,result} + win/loss/finished/turn/opponentMoves
+        return new JsonResponse(($this->sendAirRaid)($id, $x, $y, $width, $height));
     }
 }

--- a/src/Infrastructure/Http/Error/ExceptionSubscriber.php
+++ b/src/Infrastructure/Http/Error/ExceptionSubscriber.php
@@ -58,7 +58,15 @@ final class ExceptionSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // Inne wyjątki — INTERNAL_ERROR (tylko komunikat ogólny)
+        // Inne wyjątki — INTERNAL_ERROR (ogólny komunikat dla klienta,
+        // szczegóły do stderr/php-fpm, żeby 500-tki nie znikały bez śladu)
+        error_log(sprintf(
+            'INTERNAL_ERROR: %s: %s @ %s:%d',
+            $e::class,
+            $e->getMessage(),
+            $e->getFile(),
+            $e->getLine()
+        ));
         $event->setResponse($this->jsonError('Internal server error', 'INTERNAL_ERROR', 500));
     }
 
@@ -70,6 +78,14 @@ final class ExceptionSubscriber implements EventSubscriberInterface
     /** @return array{0:string,1:int} [apiCode, httpStatus] */
     private function mapDomainMessage(string $message): array
     {
+        // Bronie specjalne: komunikat zaczyna się od nazwy broni (Torpedo/Sonar/AirRaid …)
+        if (str_ends_with($message, 'not available in this ruleset')) {
+            return ['WEAPON_NOT_AVAILABLE', 422];
+        }
+        if (str_ends_with($message, 'limit reached')) {
+            return ['WEAPON_LIMIT_REACHED', 422];
+        }
+
         return match ($message) {
             'Fleet not placed' => ['FLEET_NOT_PLACED', 422],
             'Opponent fleet not placed' => ['FLEET_NOT_PLACED', 422],

--- a/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
+++ b/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
@@ -5,6 +5,7 @@ namespace App\Infrastructure\Persistence\Doctrine\Mapper;
 use App\Domain\Game\BoardSize;
 use App\Domain\Game\ClassicRuleset;
 use App\Domain\Game\Coordinate;
+use App\Domain\Game\FunRuleset;
 use App\Domain\Game\Game;
 use App\Domain\Game\GameStatus;
 use App\Domain\Game\Orientation;
@@ -52,7 +53,7 @@ final class GameSnapshotMapper
         return [
             'status' => $game->status()->value,
             'ruleset' => [
-                'type' => 'classic',
+                'type' => $game->ruleset()->name(),
                 'board' => ['w' => $size->width, 'h' => $size->height],
             ],
             'fleet' => $fleet,
@@ -66,6 +67,8 @@ final class GameSnapshotMapper
             'opponentFleet' => $opponentFleet,
             // Stan AI przeciwnika (kształt zna HuntTargetAI) – opcjonalnie
             'ai' => [] !== $game->aiState() ? $game->aiState() : null,
+            // Użycia broni specjalnych (limity trzyma Ruleset)
+            'weapons' => [] !== $game->weaponUses() ? $game->weaponUses() : null,
             // Iteration 1 meta
             'mode' => $game->mode(),
             'opponent' => $game->opponent(),
@@ -166,13 +169,21 @@ final class GameSnapshotMapper
             $game->setAiState($state['ai']);
         }
 
+        // weapon uses from snapshot (optional)
+        if (!empty($state['weapons']) && is_array($state['weapons'])) {
+            $game->setWeaponUsesFromSnapshot($state['weapons']);
+        }
+
         return $game;
     }
 
     private function rulesetFromArray(array $data): Ruleset
     {
         $board = $data['board'] ?? ['w' => 10, 'h' => 10];
+        $size = new BoardSize((int) $board['w'], (int) $board['h']);
 
-        return new ClassicRuleset(new BoardSize((int) $board['w'], (int) $board['h']));
+        return 'fun' === ($data['type'] ?? 'classic')
+            ? new FunRuleset($size)
+            : new ClassicRuleset($size);
     }
 }

--- a/tests/Functional/GameApiFunModeTest.php
+++ b/tests/Functional/GameApiFunModeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Support\FleetFactory;
+
+final class GameApiFunModeTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return App\Kernel::class;
+    }
+
+    public function testFunModeFullFlow(): void
+    {
+        $client = static::createClient();
+
+        // create fun game
+        $client->request('POST', '/api/games', server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['mode' => 'fun']));
+        self::assertResponseStatusCodeSame(201);
+        $created = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('fun', $created['ruleset']);
+        $id = $created['id'];
+
+        // place fleet
+        $client->request('POST', "/api/games/$id/fleet", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['ships' => FleetFactory::classic10x10Array()], JSON_THROW_ON_ERROR));
+        self::assertResponseIsSuccessful();
+
+        // GET exposes ruleset and weapons state
+        $client->request('GET', "/api/games/$id");
+        self::assertResponseIsSuccessful();
+        $view = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('fun', $view['ruleset']);
+        self::assertSame(['used' => 0, 'limit' => 2], $view['weapons']['torpedo']);
+        self::assertSame(['used' => 0, 'limit' => 3], $view['weapons']['sonar']);
+        self::assertSame(['used' => 0, 'limit' => 1], $view['weapons']['airRaid']);
+
+        // torpedo: full turn — results + AI response + turn back to player
+        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 5, 'direction' => 'E']));
+        self::assertResponseIsSuccessful();
+        $torpedo = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertCount(10, $torpedo['results']);
+        self::assertCount(1, $torpedo['opponentMoves']);
+        self::assertSame('player', $torpedo['turn']);
+        self::assertFalse($torpedo['finished']);
+
+        // weapon use persisted (survives repository round-trip, incl. fun ruleset)
+        $client->request('GET', "/api/games/$id");
+        $view = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['used' => 1, 'limit' => 2], $view['weapons']['torpedo']);
+        self::assertSame('fun', $view['ruleset']);
+
+        // air raid endpoint (route regression: '/api/games/{id}/air-raid' z wiodącym slashem)
+        $client->request('POST', "/api/games/$id/air-raid", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 8, 'y' => 2, 'width' => 1, 'height' => 1]));
+        self::assertResponseIsSuccessful();
+        $raid = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertCount(9, $raid['results']);
+        self::assertCount(1, $raid['opponentMoves']);
+
+        // sonar endpoint — nie zużywa tury, ale zużywa limit
+        $client->request('POST', "/api/games/$id/sonar", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 5, 'y' => 5]));
+        self::assertResponseIsSuccessful();
+
+        $client->request('GET', "/api/games/$id");
+        $view = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['used' => 1, 'limit' => 1], $view['weapons']['airRaid']);
+        self::assertSame(['used' => 1, 'limit' => 3], $view['weapons']['sonar']);
+    }
+
+    public function testWeaponsRejectedInClassicGame(): void
+    {
+        $client = static::createClient();
+
+        $client->request('POST', '/api/games', server: ['CONTENT_TYPE' => 'application/json'], content: json_encode([]));
+        $id = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR)['id'];
+
+        $client->request('POST', "/api/games/$id/fleet", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['ships' => FleetFactory::classic10x10Array()], JSON_THROW_ON_ERROR));
+        self::assertResponseIsSuccessful();
+
+        // classic → torpeda niedostępna (422 z ExceptionSubscriber)
+        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 5, 'direction' => 'E']));
+        self::assertResponseStatusCodeSame(422);
+
+        // classic → sonar niedostępny
+        $client->request('POST', "/api/games/$id/sonar", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 5, 'y' => 5]));
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    public function testInvalidModeRejected(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/api/games', server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['mode' => 'hardcore']));
+        self::assertResponseStatusCodeSame(400);
+    }
+}

--- a/tests/Functional/GameApiSonarTest.php
+++ b/tests/Functional/GameApiSonarTest.php
@@ -24,7 +24,7 @@ final class GameApiSonarTest extends WebTestCase
             'POST',
             '/api/games',
             server: ['CONTENT_TYPE' => 'application/json'],
-            content: json_encode(['width' => 10, 'height' => 10], JSON_THROW_ON_ERROR)
+            content: json_encode(['width' => 10, 'height' => 10, 'mode' => 'fun'], JSON_THROW_ON_ERROR)
         );
         self::assertResponseStatusCodeSame(201);
         $id = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR)['id'];
@@ -95,7 +95,7 @@ final class GameApiSonarTest extends WebTestCase
             'POST',
             '/api/games',
             server: ['CONTENT_TYPE' => 'application/json'],
-            content: json_encode(['width' => 10, 'height' => 10], JSON_THROW_ON_ERROR)
+            content: json_encode(['width' => 10, 'height' => 10, 'mode' => 'fun'], JSON_THROW_ON_ERROR)
         );
         self::assertResponseStatusCodeSame(201);
         $id = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR)['id'];

--- a/tests/Unit/GameApiSendAirRaidTest.php
+++ b/tests/Unit/GameApiSendAirRaidTest.php
@@ -57,6 +57,9 @@ it('pozwala przeprowadzić nalot na wybrany obszar przy narożnikach', function 
         $game->sendAirRaid($centralPoint, new Area(1, 1))
     );
 
+    // limit nalotów to 1 na grę — druga krawędź w świeżej grze
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
     $centralPoint = new Coordinate(9, 5);
 
     self::assertSame(

--- a/tests/Unit/GameSonarPingTest.php
+++ b/tests/Unit/GameSonarPingTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
-use App\Domain\Game\ClassicRuleset;
 use App\Domain\Game\Coordinate;
+use App\Domain\Game\FunRuleset;
 use App\Domain\Game\Game;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FleetFactory;
@@ -14,7 +14,7 @@ final class GameSonarPingTest extends TestCase
 {
     public function testSonarCrossFromCornerRespectsBoundsAndReportsOccupancy(): void
     {
-        $rules = new ClassicRuleset();
+        $rules = new FunRuleset();
         $game = Game::create($rules);
         $game->placeFleet(FleetFactory::classic10x10());
 

--- a/tests/Unit/GameWeaponLimitsTest.php
+++ b/tests/Unit/GameWeaponLimitsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Game\Area;
+use App\Domain\Game\BoardSize;
+use App\Domain\Game\ClassicRuleset;
+use App\Domain\Game\Coordinate;
+use App\Domain\Game\Direction;
+use App\Domain\Game\FunRuleset;
+use App\Domain\Game\Game;
+use Tests\Support\FleetFactory;
+
+function funGame(): Game
+{
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+
+    return $game;
+}
+
+it('odrzuca torpedę w klasycznym rulesecie', function () {
+    $game = Game::create(new ClassicRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+    $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+})->throws(DomainException::class, 'Torpedo not available in this ruleset');
+
+it('odrzuca sonar w klasycznym rulesecie', function () {
+    $game = Game::create(new ClassicRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+    $game->sonarPing(new Coordinate(5, 5));
+})->throws(DomainException::class, 'Sonar not available in this ruleset');
+
+it('egzekwuje limit torped na grę', function () {
+    $game = funGame();
+    $game->fireTorpedo(new Coordinate(0, 5), Direction::E);
+    $game->fireTorpedo(new Coordinate(0, 7), Direction::E);
+    $game->fireTorpedo(new Coordinate(0, 9), Direction::E);
+})->throws(DomainException::class, 'Torpedo limit reached');
+
+it('egzekwuje limit sonarów na grę', function () {
+    $game = funGame();
+    $game->sonarPing(new Coordinate(5, 5));
+    $game->sonarPing(new Coordinate(2, 2));
+    $game->sonarPing(new Coordinate(7, 7));
+    $game->sonarPing(new Coordinate(4, 4));
+})->throws(DomainException::class, 'Sonar limit reached');
+
+it('egzekwuje limit nalotów na grę', function () {
+    $game = funGame();
+    $game->sendAirRaid(new Coordinate(5, 5), new Area(1, 1));
+    $game->sendAirRaid(new Coordinate(2, 2), new Area(1, 1));
+})->throws(DomainException::class, 'AirRaid limit reached');
+
+it('raportuje stan broni: użycia i limity', function () {
+    $game = funGame();
+    $game->fireTorpedo(new Coordinate(0, 5), Direction::E);
+    $game->sonarPing(new Coordinate(5, 5));
+
+    expect($game->weaponsState())->toBe([
+        'torpedo' => ['used' => 1, 'limit' => 2],
+        'sonar' => ['used' => 1, 'limit' => 3],
+        'airRaid' => ['used' => 0, 'limit' => 1],
+    ]);
+});
+
+it('nieudany nalot (oversize) nie zużywa limitu', function () {
+    $game = funGame();
+    try {
+        $game->sendAirRaid(new Coordinate(5, 5), new Area(3, 3));
+    } catch (DomainException) {
+        // oversize — oczekiwane
+    }
+
+    expect($game->weaponsState()['airRaid']['used'])->toBe(0);
+    // limit wciąż dostępny
+    $game->sendAirRaid(new Coordinate(5, 5), new Area(1, 1));
+    expect($game->weaponsState()['airRaid']['used'])->toBe(1);
+});


### PR DESCRIPTION
Closes #9

## Zakres

**Domena / API** (commit 1):
- `Ruleset::name()` + `weaponLimits()` — fun: 🚀 torpeda ×2, 📡 sonar ×3, ✈️ nalot ×1; classic: bronie niedostępne
- `Game`: licznik użyć + gating (`WEAPON_NOT_AVAILABLE`/`WEAPON_LIMIT_REACHED`, 422); nieudana walidacja (np. oversize) nie zużywa limitu
- `POST /api/games` przyjmuje `mode: classic|fun`; `GET` zwraca `ruleset` + `weapons`
- `OpponentTurn` — wspólna odpowiedź AI: **torpeda i nalot kosztują turę** (dotąd były darmową akcją bez reakcji AI), sonar nie zużywa tury
- sonar przestał być dostępny w classic (testy przeniesione na fun)

**Frontend** (commit 2): wybór wariantu na Home, panel broni z licznikami i wyszarzaniem, kierunek torpedy, overlay sonaru (statek/woda) na mgle przeciwnika.

## Dwa znalezione bugi po drodze

1. **Gra fun nie przeżywała persystencji** — mapper hardcodował typ rulesetu na `classic` przy zapisie i odczycie; po wczytaniu z bazy torpeda rzucała wyjątkiem. Teraz snapshot niesie prawdziwy typ.
2. **Endpoint nalotu nigdy nie działał przez HTTP** — route `{id}/air-raid` bez wiodącego slasha dawał ścieżkę `/api/games{id}/air-raid`. Nalot miał wyłącznie testy unit; dołożony test funkcjonalny endpointu. Przy okazji `ExceptionSubscriber` loguje nieznane wyjątki do stderr przed zwróceniem 500 (ten bug był niediagnozowalny bez tego).

## Weryfikacja

- Pełny Pest w Dockerze: **75 passed, 1221 assertions** (nowe: limity per broń, dostępność per ruleset, oversize nie zużywa limitu, pełny flow fun przez API, invalid mode → 400)
- PHPStan: No errors; cs-fixer czysty; `npm run build` OK
- Przeglądarka (pełny stack): gra fun od utworzenia po rozgrywkę — torpeda zmiata wiersz + AI odpowiada, sonar rysuje krzyż promienia 3, nalot 3×3, liczniki schodzą, wyczerpane bronie wyszarzone, tryb wraca do strzału

🤖 Generated with [Claude Code](https://claude.com/claude-code)