### PR TITLE
UX feedback: sunk visibility fix, board sizes, weapon range preview, animations

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -55,9 +55,8 @@ export interface ShotResultDTO {
     opponentMoves: { x: number; y: number; result: 'hit' | 'miss' | 'sunk' | 'duplicate' }[];
 }
 
-export async function createGame(mode: RulesetName = 'classic'): Promise<CreateGameResponse> {
-    // backend przyjmuje opcjonalne width/height/mode
-    return http.post<CreateGameResponse>('/games', { mode });
+export async function createGame(mode: RulesetName = 'classic', size = 10): Promise<CreateGameResponse> {
+    return http.post<CreateGameResponse>('/games', { mode, width: size, height: size });
 }
 
 export async function getGame(id: string): Promise<GameViewDTO> {

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -1,19 +1,72 @@
 <script setup lang="ts">
 import GameGameBoard from './GameBoard.vue';
 import { useGame } from '../composables/useGame';
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 // Destrukturyzacja: ref-y stają się top-level, więc template odpakowuje je
 // automatycznie (zagnieżdżone w zwykłym obiekcie NIE są odpakowywane).
 const {
-    status, finished, turn, loading, error, disabled, attack,
+    status, finished, turn, loading, error, disabled, attack, width, height,
     ruleset, weapons, weaponMode, torpedoDirection, sonarMarks,
     shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
     toast, toastType,
     playerGrid, playerUnderFireOverlay, enemyFogGrid, lastShot, sunkCells,
 } = useGame();
 const router = useRouter();
+
+// Podgląd zasięgu aktywnej broni pod kursorem (plansza przeciwnika)
+const hoverCell = ref<{ x: number; y: number } | null>(null);
+
+const previewCells = computed<Set<string>>(() => {
+    const set = new Set<string>();
+    const hc = hoverCell.value;
+    if (!hc || disabled.value) return set;
+    const w = width.value;
+    const h = height.value;
+    const add = (x: number, y: number) => {
+        if (x >= 0 && y >= 0 && x < w && y < h) set.add(`${x}:${y}`);
+    };
+
+    switch (weaponMode.value) {
+        case 'torpedo': {
+            const [dx, dy] = { N: [0, -1], S: [0, 1], E: [1, 0], W: [-1, 0] }[torpedoDirection.value];
+            let cx = hc.x, cy = hc.y;
+            while (cx >= 0 && cy >= 0 && cx < w && cy < h) {
+                set.add(`${cx}:${cy}`);
+                cx += dx;
+                cy += dy;
+            }
+            break;
+        }
+        case 'sonar':
+            add(hc.x, hc.y);
+            for (let i = 1; i <= 3; i++) {
+                add(hc.x, hc.y - i);
+                add(hc.x + i, hc.y);
+                add(hc.x, hc.y + i);
+                add(hc.x - i, hc.y);
+            }
+            break;
+        case 'airraid':
+            for (let dx = -1; dx <= 1; dx++) {
+                for (let dy = -1; dy <= 1; dy++) add(hc.x + dx, hc.y + dy);
+            }
+            break;
+        default:
+            break; // zwykły strzał — bez podglądu
+    }
+
+    return set;
+});
+
+function handleHover(x: number, y: number) {
+    hoverCell.value = { x, y };
+}
+
+function handleBoardLeave() {
+    hoverCell.value = null;
+}
 
 // Połącz siatkę gracza z overlayem strzałów przeciwnika (opp-hit/opp-miss)
 const mergedPlayerGrid = computed<string[][]>(() => {
@@ -39,6 +92,11 @@ const enemyAnimatedGrid = computed<string[][]>(() => {
         // Skan sonaru — tylko na polach jeszcze nieostrzelanych
         if (cell === 'empty' && sonar.has(`${x}:${y}`)) {
             classes += sonar.get(`${x}:${y}`) ? ' sonar-ship' : ' sonar-water';
+        }
+
+        // Podgląd zasięgu broni pod kursorem
+        if (previewCells.value.has(`${x}:${y}`)) {
+            classes += ' preview';
         }
 
         // Zatopione statki – stała klasa 'sink'
@@ -99,7 +157,8 @@ function newGame() {
 
         <div>
             <h3>Przeciwnik</h3>
-            <GameGameBoard :grid="enemyAnimatedGrid" :onCellClick="handleShot" :disabled="disabled" />
+            <GameGameBoard :grid="enemyAnimatedGrid" :onCellClick="handleShot" :disabled="disabled"
+                           :onCellHover="handleHover" :onBoardLeave="handleBoardLeave" />
 
             <!-- Panel broni specjalnych (tylko tryb fun) -->
             <div v-if="ruleset === 'fun' && weapons" class="weapons">
@@ -145,6 +204,7 @@ function newGame() {
                 <div class="legend">
                     <span class="item"><span class="box ship"></span> Statek (Twoja plansza)</span>
                     <span class="item"><span class="box hit"></span> Trafienie</span>
+                    <span class="item"><span class="box sink"></span> Zatopiony</span>
                     <span class="item"><span class="box miss"></span> Pudło</span>
                     <span class="item"><span class="box opp-hit"></span> Trafienie przeciwnika</span>
                     <span class="item"><span class="box opp-miss"></span> Pudło przeciwnika</span>
@@ -182,6 +242,11 @@ function newGame() {
 .legend .box { width:16px; height:16px; border:1px solid #cbd5e1; border-radius:2px; display:inline-block; }
 .legend .box.ship { background:#94a3b8; }
 .legend .box.hit { background:#ef4444; border-color:#ef4444; }
+.legend .box.sink {
+    background:#7f1d1d; border-color:#7f1d1d;
+    background-image: linear-gradient(45deg, transparent 40%, #fecaca 40%, #fecaca 60%, transparent 60%),
+        linear-gradient(-45deg, transparent 40%, #fecaca 40%, #fecaca 60%, transparent 60%);
+}
 .legend .box.miss { background:#bfdbfe; border-color:#bfdbfe; }
 .legend .box.opp-hit { background: transparent; border-color:#7a0a0a; box-shadow: inset 0 0 0 2px #7a0a0a; }
 .legend .box.opp-miss { background: transparent; border-color:#0c4a6e; box-shadow: inset 0 0 0 2px #0c4a6e; }

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -8,6 +8,8 @@ const props = defineProps<{
     // Dopuszczamy boolean lub Ref<boolean>
     disabled?: unknown;
     onCellClick?: (x: number, y: number) => void;
+    onCellHover?: (x: number, y: number) => void;
+    onBoardLeave?: () => void;
 }>();
 
 // Przyjmujemy dowolne klasy komórek (np. 'ship', 'hit', 'miss', 'opp-hit', 'opp-miss')
@@ -29,7 +31,8 @@ function handleClick(x: number, y: number) {
 
 <template>
     <div class="grid" :class="{ disabled: normalizedDisabled }"
-         :style="{ gridTemplateRows: `repeat(${normalizedGrid?.length || 0}, 30px)` }">
+         :style="{ gridTemplateRows: `repeat(${normalizedGrid?.length || 0}, 30px)` }"
+         @mouseleave="props.onBoardLeave?.()">
         <div
             v-for="(row, y) in normalizedGrid"
             :key="y"
@@ -43,6 +46,7 @@ function handleClick(x: number, y: number) {
                 :class="cell"
                 :title="typeof cell === 'string' && (cell.includes('opp-hit') || cell.includes('opp-miss')) ? (cell.includes('opp-hit') ? 'Trafienie przeciwnika' : 'Pudło przeciwnika') : ''"
                 @click="handleClick(x, y)"
+                @mouseenter="props.onCellHover?.(x, y)"
             />
         </div>
     </div>
@@ -169,21 +173,24 @@ function handleClick(x: number, y: number) {
 }
 
 /* ===================== */
-/* ZATOPIENIE (opcjonalnie) */
+/* ZATOPIENIE            */
 /* ===================== */
 
+/* Ciemna czerwień + jasny krzyżyk — jednoznacznie różne od trafienia (czerwień)
+   i od szarego statku na planszy gracza */
 .cell.sink {
-    animation: sinkPulse 600ms ease-out infinite alternate;
-    background: #6b7280; /* ciemniejszy szary */
+    background-color: #7f1d1d;
+    background-image:
+        linear-gradient(45deg, transparent 42%, #fecaca 42%, #fecaca 58%, transparent 58%),
+        linear-gradient(-45deg, transparent 42%, #fecaca 42%, #fecaca 58%, transparent 58%);
 }
 
-@keyframes sinkPulse {
-    0% {
-        filter: brightness(100%);
-    }
-    100% {
-        filter: brightness(70%);
-    }
+/* ===================== */
+/* PODGLĄD ZASIĘGU BRONI */
+/* ===================== */
+
+.cell.preview {
+    box-shadow: inset 0 0 0 3px rgba(31, 111, 235, 0.55);
 }
 
 </style>

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -117,6 +117,8 @@ export function useGame() {
             && status.value !== 'won' && status.value !== 'lost';
     }
 
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
     async function start() {
         loading.value = true;
         error.value = '';
@@ -197,6 +199,15 @@ export function useGame() {
         try {
             shooting.value = true;
             const res = await fireTorpedo(gameId.value, x, y, torpedoDirection.value);
+            // animacja przejścia: odsłaniaj tor komórka po komórce
+            for (const cell of res.results) {
+                if (cell.result !== 'duplicate' && enemyFogGrid.value[cell.y]?.[cell.x] !== undefined) {
+                    enemyFogGrid.value[cell.y][cell.x] = cell.result === 'miss' ? 'miss' : 'hit';
+                }
+                lastShot.value = { x: cell.x, y: cell.y, result: cell.result };
+                await sleep(90);
+            }
+            lastShot.value = null;
             applyTurnOutcome(res);
             await refresh();
         } catch (e: any) {
@@ -212,10 +223,21 @@ export function useGame() {
         try {
             shooting.value = true;
             const res = await sonarPing(gameId.value, x, y);
-            // dopisz skan (nadpisując wcześniejsze wpisy dla tych samych pól)
+            // animacja: odsłaniaj skan od środka na zewnątrz
+            const ordered = [...res.results].sort(
+                (a, b) => (Math.abs(a.x - x) + Math.abs(a.y - y)) - (Math.abs(b.x - x) + Math.abs(b.y - y))
+            );
             const merged = new Map(sonarMarks.value.map(c => [`${c.x}:${c.y}`, c]));
-            for (const c of res.results) merged.set(`${c.x}:${c.y}`, c);
-            sonarMarks.value = [...merged.values()];
+            let lastDistance = -1;
+            for (const c of ordered) {
+                const distance = Math.abs(c.x - x) + Math.abs(c.y - y);
+                if (distance !== lastDistance) {
+                    await sleep(140);
+                    lastDistance = distance;
+                }
+                merged.set(`${c.x}:${c.y}`, c);
+                sonarMarks.value = [...merged.values()];
+            }
             await refresh(); // licznik użyć
         } catch (e: any) {
             showToast(e?.message ?? 'Sonar nie zadziałał', 'warn', 2500);
@@ -277,7 +299,7 @@ export function useGame() {
     }
 
     return {
-        gameId, size, playerGrid, playerUnderFireOverlay, enemyFogGrid, turn, status, finished,
+        gameId, size, width, height, playerGrid, playerUnderFireOverlay, enemyFogGrid, turn, status, finished,
         loading, error, start, refresh, shot, attack, disabled,
         // tryb fun
         ruleset, weapons, weaponMode, torpedoDirection, sonarMarks,

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -15,6 +15,13 @@
             </label>
         </fieldset>
 
+        <fieldset class="mode">
+            <legend>Rozmiar planszy</legend>
+            <label><input type="radio" :value="10" v-model="size" /> 10 × 10 — klasyka</label>
+            <label><input type="radio" :value="12" v-model="size" /> 12 × 12 — więcej wody</label>
+            <label><input type="radio" :value="15" v-model="size" /> 15 × 15 — polowanie</label>
+        </fieldset>
+
         <button class="btn" :disabled="loading" @click="onNewGame">
             {{ loading ? 'Tworzenie…' : 'Nowa gra' }}
         </button>
@@ -32,12 +39,13 @@ const router = useRouter()
 const loading = ref(false)
 const error = ref('')
 const mode = ref<RulesetName>('classic')
+const size = ref(10)
 
 async function onNewGame() {
   loading.value = true
   error.value = ''
   try {
-    const g = await createGame(mode.value)
+    const g = await createGame(mode.value, size.value)
     await router.push({ name: 'place-fleet', params: { id: g.id } })
   } catch (e: any) {
     error.value = e?.message ?? 'Nie udało się utworzyć gry'

--- a/frontend/src/views/PlaceFleet.vue
+++ b/frontend/src/views/PlaceFleet.vue
@@ -21,8 +21,8 @@
         </div>
       </div>
 
-      <div class="board" role="grid">
-        <div class="row" v-for="y in height" :key="y">
+      <div class="board" role="grid" :style="{ gridTemplateRows: `repeat(${height}, 30px)` }">
+        <div class="row" v-for="y in height" :key="y" :style="{ gridTemplateColumns: `repeat(${width}, 30px)` }">
           <div
             class="cell"
             v-for="x in width"
@@ -54,9 +54,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { placeFleet, type PlayerFleetItem } from '../api/gameApi'
+import { getGame, placeFleet, type PlayerFleetItem } from '../api/gameApi'
 
 const route = useRoute()
 const router = useRouter()
@@ -66,8 +66,19 @@ const loading = ref(false)
 const error = ref('')
 const hint = ref('Kliknij pole, aby postawić kolejny statek. Zmieniaj orientację w toolbarze.')
 
-const width = 10
-const height = 10
+// wymiary planszy z gry (10×10 to tylko start do czasu odpowiedzi API)
+const width = ref(10)
+const height = ref(10)
+
+onMounted(async () => {
+  try {
+    const g = await getGame(id)
+    width.value = g.board.w
+    height.value = g.board.h
+  } catch {
+    // zostają domyślne 10×10; błąd i tak wyjdzie przy zapisie floty
+  }
+})
 
 // Inwentarz klasyczny: 1×4, 2×3, 3×2, 4×1
 const inventory = ref<number[]>([4,3,3,2,2,2,1,1,1,1])
@@ -148,8 +159,8 @@ function isOccupiedOrAdjacent(x: number, y: number): boolean {
 }
 
 function fitsInside(x: number, y: number, len: number, o: 'h'|'v'): boolean {
-  if (o === 'h') return x >= 0 && y >= 0 && x + len - 1 < width && y < height
-  return x >= 0 && y >= 0 && x < width && y + len - 1 < height
+  if (o === 'h') return x >= 0 && y >= 0 && x + len - 1 < width.value && y < height.value
+  return x >= 0 && y >= 0 && x < width.value && y + len - 1 < height.value
 }
 
 function canStartHere(x: number, y: number, len: number, o: 'h'|'v'): boolean {
@@ -233,8 +244,8 @@ function goBack() { router.back() }
 .toolbar .segment { display: flex; gap: .5rem; align-items: center; }
 .pill { display: inline-block; padding: .15rem .4rem; border-radius: 10px; background: #f2f2f2; border: 1px solid #ddd; margin-right: .25rem; }
 
-.board { display: grid; grid-template-rows: repeat(10, 30px); gap: 2px; }
-.row { display: grid; grid-template-columns: repeat(10, 30px); gap: 2px; }
+.board { display: grid; gap: 2px; }
+.row { display: grid; gap: 2px; }
 .cell { width: 30px; height: 30px; border: 1px solid #cbd5e1; background: #f8fafc; cursor: pointer; }
 .cell.ship { background: #94a3b8; }
 .cell.preview { outline: 2px solid #16a34a; outline-offset: -2px; background: #dcfce7; }

--- a/src/Application/Game/GetShots.php
+++ b/src/Application/Game/GetShots.php
@@ -3,7 +3,6 @@
 namespace App\Application\Game;
 
 use App\Domain\Game\GameRepository;
-use App\Domain\Game\Orientation;
 use App\Domain\Shared\GameId;
 
 final class GetShots
@@ -20,36 +19,9 @@ final class GetShots
             throw new \InvalidArgumentException('Game not found');
         }
 
-        $shots = $game->shotsWithResults();
-
-        // Collect hit cells (hit or sunk)
-        $hitSet = [];
-        foreach ($shots as $s) {
-            if ('hit' === $s['result'] || 'sunk' === $s['result']) {
-                $hitSet[$s['x'].':'.$s['y']] = true;
-            }
-        }
-
-        $finished = false;
-        $fleet = $game->fleet();
-        if ($fleet) {
-            $allHit = true;
-            foreach ($fleet as $ship) {
-                for ($i = 0; $i < $ship->length; ++$i) {
-                    $x = $ship->start->x + (Orientation::H === $ship->orientation ? $i : 0);
-                    $y = $ship->start->y + (Orientation::V === $ship->orientation ? $i : 0);
-                    if (!isset($hitSet["$x:$y"])) {
-                        $allHit = false;
-                        break 2;
-                    }
-                }
-            }
-            $finished = $allHit;
-        }
-
         return [
-            'finished' => $finished,
-            'shots' => $shots,
+            'finished' => $game->isFinished(),
+            'shots' => $game->shotsWithResults(),
         ];
     }
 }

--- a/src/Infrastructure/Http/Controller/GameQueryController.php
+++ b/src/Infrastructure/Http/Controller/GameQueryController.php
@@ -3,7 +3,6 @@
 namespace App\Infrastructure\Http\Controller;
 
 use App\Domain\Game\GameRepository;
-use App\Domain\Game\Orientation;
 use App\Domain\Shared\GameId;
 use App\Infrastructure\Http\Error\ApiException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -45,22 +44,21 @@ final class GameQueryController
             }
         }
 
-        // sunk ships cells
+        // sunk ships cells — liczone względem floty PRZECIWNIKA (to w nią strzela gracz);
+        // fallback na flotę gracza dla starych gier bez floty przeciwnika
         $sunk = [];
         $hitSet = [];
         foreach ($hits as $h) {
             $hitSet[$h[0].':'.$h[1]] = true;
         }
 
-        $fleet = $game->fleet() ?? [];
-        foreach ($fleet as $ship) {
+        $targetFleet = $game->opponentFleet() ?? $game->fleet() ?? [];
+        foreach ($targetFleet as $ship) {
             $cells = [];
             $allHit = true;
-            for ($i = 0; $i < $ship->length; ++$i) {
-                $x = $ship->start->x + (Orientation::H === $ship->orientation ? $i : 0);
-                $y = $ship->start->y + (Orientation::V === $ship->orientation ? $i : 0);
-                $cells[] = [$x, $y];
-                if (!isset($hitSet["$x:$y"])) {
+            foreach ($ship->cells() as $c) {
+                $cells[] = [$c->x, $c->y];
+                if (!isset($hitSet["{$c->x}:{$c->y}"])) {
                     $allHit = false;
                 }
             }
@@ -80,7 +78,7 @@ final class GameQueryController
                 'o' => $s->orientation->value,
                 'l' => $s->length,
             ];
-        }, $fleet);
+        }, $game->fleet() ?? []);
 
         $turn = $finished ? 'none' : $game->turn();
 

--- a/tests/Functional/GameApiSunkProjectionTest.php
+++ b/tests/Functional/GameApiSunkProjectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class GameApiSunkProjectionTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return App\Kernel::class;
+    }
+
+    /**
+     * Regresja: enemyFogGrid.sunk było liczone względem floty GRACZA zamiast
+     * przeciwnika — niewidoczne w testach z identycznymi flotami, więc flota
+     * gracza jest tu celowo INNA niż deterministyczna flota przeciwnika.
+     */
+    public function testSunkShipsComputedAgainstOpponentFleet(): void
+    {
+        $client = static::createClient();
+
+        $client->request('POST', '/api/games', server: ['CONTENT_TYPE' => 'application/json'], content: json_encode([]));
+        $id = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR)['id'];
+
+        // Alternatywny, poprawny układ klasycznej floty (bez styku), różny od FleetFactory
+        $altFleet = [
+            ['x' => 0, 'y' => 9, 'o' => 'H', 'l' => 4],
+            ['x' => 5, 'y' => 9, 'o' => 'H', 'l' => 3],
+            ['x' => 9, 'y' => 0, 'o' => 'V', 'l' => 3],
+            ['x' => 0, 'y' => 0, 'o' => 'V', 'l' => 2],
+            ['x' => 2, 'y' => 1, 'o' => 'H', 'l' => 2],
+            ['x' => 5, 'y' => 3, 'o' => 'V', 'l' => 2],
+            ['x' => 7, 'y' => 1, 'o' => 'H', 'l' => 1],
+            ['x' => 0, 'y' => 4, 'o' => 'H', 'l' => 1],
+            ['x' => 3, 'y' => 6, 'o' => 'H', 'l' => 1],
+            ['x' => 7, 'y' => 6, 'o' => 'H', 'l' => 1],
+        ];
+        $client->request('POST', "/api/games/$id/fleet", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['ships' => $altFleet], JSON_THROW_ON_ERROR));
+        self::assertResponseIsSuccessful();
+
+        // Flota przeciwnika (deterministyczna w env testowym) ma jedynkę na (0,6);
+        // gracz na (0,6) nie ma nic — strzał zatapia statek przeciwnika.
+        $client->request('POST', "/api/games/$id/shots", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 6]));
+        self::assertResponseIsSuccessful();
+        $shot = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('sunk', $shot['result']);
+
+        // Projekcja musi raportować zatopioną jedynkę przeciwnika na (0,6)
+        $client->request('GET', "/api/games/$id");
+        $view = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame([['cells' => [[0, 6]]]], $view['enemyFogGrid']['sunk']);
+    }
+}


### PR DESCRIPTION
Feedback z pierwszych rozgrywek fun mode (2026-07-11), 3 commity:

## 1. Bug: zatopienia niewidoczne + „tajemniczy szary kwadrat" (jedno źródło!)

`enemyFogGrid.sunk` było liczone względem floty **gracza** zamiast przeciwnika — w env testowym niewykrywalne (identyczne floty), w realnej grze przypadkowe pojedyncze komórki dostawały szarą klasę `sink` (stąd tajemniczy kwadrat „w trójmasztowcu"), a prawdziwe zatopienia nie były oznaczane wcale. `GetShots.finished` miał ten sam cross-board problem. Test regresyjny z flotą gracza celowo inną niż deterministyczna flota przeciwnika (czerwony przed fixem).

## 2. Rozmiar planszy

Wybór 10×10 / 12×12 / 15×15 przy tworzeniu gry; `PlaceFleet.vue` przestał mieć zahardkodowane 10×10 (wymiary z API).

## 3. UX broni

- **zatopione**: ciemna czerwień z jasnym ✕ (dotąd szarość myląca się z kolorem statku) + wpis w legendzie
- **podgląd zasięgu** pod kursorem: linia torpedy wg kierunku, krzyż sonaru, obszar nalotu
- **animacje**: torpeda odsłania tor komórka po komórce, sonar od środka na zewnątrz

Feedback „AI nie używa broni" → wydzielony do #22 (heurystyka użycia + limity per strona wymagają decyzji projektowych).

## Weryfikacja

Pest: **76 passed** (nowy test regresji), PHPStan/cs-fixer/vue-tsc czyste. Przeglądarka (fun 12×12): plansza 12×12 w rozstawianiu i grze, hover-krzyż sonaru, animacja skanu od środka, polowanie sonar→strzały→**zatopiony dwumasztowiec z ✕**, odpowiedzi AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)