### PR TITLE
Require torpedo launch from an unsunk player ship

### DIFF
--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -8,7 +8,7 @@ import { useRouter } from 'vue-router'
 // automatycznie (zagnieżdżone w zwykłym obiekcie NIE są odpakowywane).
 const {
     status, finished, turn, loading, error, disabled, attack, width, height,
-    ruleset, weapons, weaponMode, torpedoDirection, sonarMarks,
+    ruleset, weapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
     shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
     toast, toastType,
     playerGrid, playerUnderFireOverlay, enemyFogGrid, lastShot, sunkCells,
@@ -74,10 +74,17 @@ const mergedPlayerGrid = computed<string[][]>(() => {
     const ov = playerUnderFireOverlay.value;
     if (base.length !== ov.length) return base;
     return base.map((row, y) => row.map((cell, x) => {
+        let classes: string = cell;
         const o = ov[y]?.[x] ?? 'none';
-        if (o === 'none') return cell as string;
-        // złącz klasy, aby widoczny był statek i overlay
-        return `${cell} ${o}`.trim();
+        if (o !== 'none') {
+            // złącz klasy, aby widoczny był statek i overlay
+            classes += ` ${o}`;
+        }
+        // tryb torpedy: podświetl legalne wyrzutnie (niezatopione statki)
+        if (weaponMode.value === 'torpedo' && launchableCells.value.has(`${x}:${y}`)) {
+            classes += ' launch';
+        }
+        return classes.trim();
     }));
 });
 
@@ -129,7 +136,7 @@ function selectWeapon(mode: 'shot' | 'torpedo' | 'sonar' | 'airraid') {
 
 const weaponHint = computed(() => {
     switch (weaponMode.value) {
-        case 'torpedo': return 'Kliknij pole startowe torpedy — popłynie w wybranym kierunku do krawędzi.';
+        case 'torpedo': return 'Kliknij WŁASNY niezatopiony statek (podświetlony na Twojej planszy) — torpeda popłynie z jego pozycji w wybranym kierunku.';
         case 'sonar': return 'Kliknij centrum skanu — sonar sprawdzi krzyż o promieniu 3.';
         case 'airraid': return 'Kliknij centrum nalotu — ostrzał obszaru 3×3.';
         default: return '';
@@ -151,14 +158,20 @@ function newGame() {
     <div class="boards">
         <div>
             <h3>Twoja plansza</h3>
-            <!-- Pozostawiamy aktywną (niezablokowaną), aby overlay był w pełni czytelny -->
-            <GameGameBoard :grid="mergedPlayerGrid" :disabled="false" />
+            <!-- Pozostawiamy aktywną (niezablokowaną), aby overlay był w pełni czytelny;
+                 w trybie torpedy to TU wybiera się wyrzutnię -->
+            <GameGameBoard :grid="mergedPlayerGrid" :disabled="false"
+                           :onCellClick="weaponMode === 'torpedo' ? handleShot : undefined"
+                           :onCellHover="weaponMode === 'torpedo' ? handleHover : undefined"
+                           :onBoardLeave="handleBoardLeave" />
         </div>
 
         <div>
             <h3>Przeciwnik</h3>
-            <GameGameBoard :grid="enemyAnimatedGrid" :onCellClick="handleShot" :disabled="disabled"
-                           :onCellHover="handleHover" :onBoardLeave="handleBoardLeave" />
+            <GameGameBoard :grid="enemyAnimatedGrid" :disabled="disabled"
+                           :onCellClick="weaponMode === 'torpedo' ? undefined : handleShot"
+                           :onCellHover="weaponMode === 'torpedo' ? undefined : handleHover"
+                           :onBoardLeave="handleBoardLeave" />
 
             <!-- Panel broni specjalnych (tylko tryb fun) -->
             <div v-if="ruleset === 'fun' && weapons" class="weapons">

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -193,4 +193,10 @@ function handleClick(x: number, y: number) {
     box-shadow: inset 0 0 0 3px rgba(31, 111, 235, 0.55);
 }
 
+/* Wyrzutnia torpedy: własny niezatopiony statek (tryb torpedy) */
+.cell.launch {
+    box-shadow: inset 0 0 0 3px #16a34a;
+    cursor: pointer;
+}
+
 </style>

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -3,7 +3,7 @@ import { useRoute } from 'vue-router';
 import {
     getGame, fireShot, fireTorpedo, sonarPing, sendAirRaid,
     type GameViewDTO, type ShotResultDTO, type RulesetName, type WeaponsState,
-    type TorpedoDirection, type TurnOutcomeDTO, type SonarCell,
+    type TorpedoDirection, type TurnOutcomeDTO, type SonarCell, type PlayerFleetItem,
 } from '../api/gameApi.ts';
 
 export type WeaponMode = 'shot' | 'torpedo' | 'sonar' | 'airraid';
@@ -41,6 +41,8 @@ export function useGame() {
     const torpedoDirection = ref<TorpedoDirection>('E');
     // Wyniki sonaru — tylko po stronie klienta (backend nie zapisuje skanów)
     const sonarMarks = ref<SonarCell[]>([]);
+    // Flota gracza (do wyznaczania wyrzutni torped)
+    const playerFleet = ref<PlayerFleetItem[]>([]);
 
 
     function buildEmptyGrid<T extends string>(w: number, h: number, fill: T): T[][] {
@@ -102,7 +104,31 @@ export function useGame() {
         finished.value = dto.finished;
         ruleset.value = dto.ruleset ?? 'classic';
         weapons.value = dto.weapons ?? null;
+        playerFleet.value = dto.playerFleet ?? [];
     }
+
+    /**
+     * Komórki własnych NIEZATOPIONYCH statków — legalne wyrzutnie torped
+     * (reguła domenowa: torpeda startuje z żywego statku gracza).
+     */
+    const launchableCells = computed<Set<string>>(() => {
+        const set = new Set<string>();
+        const ov = playerUnderFireOverlay.value;
+        for (const s of playerFleet.value) {
+            const cells: Array<[number, number]> = [];
+            let sunk = true;
+            for (let i = 0; i < s.l; i++) {
+                const x = s.x + ((s.o as string).toLowerCase() === 'h' ? i : 0);
+                const y = s.y + ((s.o as string).toLowerCase() === 'v' ? i : 0);
+                cells.push([x, y]);
+                if (ov[y]?.[x] !== 'opp-hit') sunk = false;
+            }
+            if (!sunk) {
+                for (const [x, y] of cells) set.add(`${x}:${y}`);
+            }
+        }
+        return set;
+    });
 
     function applyTurnOutcome(o: TurnOutcomeDTO) {
         turn.value = o.turn;
@@ -302,7 +328,7 @@ export function useGame() {
         gameId, size, width, height, playerGrid, playerUnderFireOverlay, enemyFogGrid, turn, status, finished,
         loading, error, start, refresh, shot, attack, disabled,
         // tryb fun
-        ruleset, weapons, weaponMode, torpedoDirection, sonarMarks,
+        ruleset, weapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
         // stats
         shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
         // toast

--- a/src/Domain/Game/BoardSide.php
+++ b/src/Domain/Game/BoardSide.php
@@ -108,6 +108,14 @@ final class BoardSide
         return null !== $this->shipAtKey($x.':'.$y);
     }
 
+    /** Czy na polu stoi statek, który NIE został jeszcze zatopiony. */
+    public function hasUnsunkShipAt(int $x, int $y): bool
+    {
+        $ship = $this->shipAtKey($x.':'.$y);
+
+        return null !== $ship && !$this->isSunk($ship);
+    }
+
     /** @return list<array{x:int,y:int}> */
     public function shotsTaken(): array
     {

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -267,21 +267,23 @@ final class Game
         }
     }
 
-    /**
-     * Zużywa jedno użycie broni; rzuca, gdy broń niedostępna w rulesecie
-     * albo limit na grę wyczerpany.
-     */
-    private function consumeWeapon(string $weapon): void
+    /** Rzuca, gdy broń niedostępna w rulesecie albo limit na grę wyczerpany. */
+    private function assertWeaponAvailable(string $weapon): void
     {
         $limit = $this->ruleset->weaponLimits()[$weapon] ?? 0;
         if ($limit <= 0) {
             throw new \DomainException(sprintf('%s not available in this ruleset', ucfirst($weapon)));
         }
-        $used = $this->weaponUses[$weapon] ?? 0;
-        if ($used >= $limit) {
+        if (($this->weaponUses[$weapon] ?? 0) >= $limit) {
             throw new \DomainException(sprintf('%s limit reached', ucfirst($weapon)));
         }
-        $this->weaponUses[$weapon] = $used + 1;
+    }
+
+    /** Zużywa jedno użycie broni (po przejściu wszystkich walidacji). */
+    private function consumeWeapon(string $weapon): void
+    {
+        $this->assertWeaponAvailable($weapon);
+        $this->weaponUses[$weapon] = ($this->weaponUses[$weapon] ?? 0) + 1;
     }
 
     /** Strzały gracza. @return list<array{x:int,y:int}> */
@@ -332,6 +334,9 @@ final class Game
      * Torpedo: moves across the entire board in a given direction.
      * For each cell along the line it calls fireShot() and returns the list of results.
      *
+     * Torpeda musi być odpalona z pozycji własnego, NIEZATOPIONEGO statku —
+     * pozycje żywej floty gracza wyznaczają dostępne linie ostrzału.
+     *
      * @return list<array{x:int,y:int,result:string}>
      */
     public function fireTorpedo(Coordinate $start, Direction $direction): array
@@ -340,11 +345,17 @@ final class Game
             throw new \DomainException('Fleet not placed');
         }
 
+        $this->assertWeaponAvailable('torpedo');
+
         $w = $this->ruleset->boardSize()->width;
         $h = $this->ruleset->boardSize()->height;
 
         if ($start->x >= $w || $start->y >= $h) {
             throw new \DomainException('Torpedo start outside board');
+        }
+
+        if (!$this->playerSide->hasUnsunkShipAt($start->x, $start->y)) {
+            throw new \DomainException('Torpedo must be launched from an unsunk ship');
         }
 
         $this->consumeWeapon('torpedo');

--- a/src/Infrastructure/Http/Error/ExceptionSubscriber.php
+++ b/src/Infrastructure/Http/Error/ExceptionSubscriber.php
@@ -85,6 +85,9 @@ final class ExceptionSubscriber implements EventSubscriberInterface
         if (str_ends_with($message, 'limit reached')) {
             return ['WEAPON_LIMIT_REACHED', 422];
         }
+        if ('Torpedo must be launched from an unsunk ship' === $message) {
+            return ['TORPEDO_LAUNCH_INVALID', 422];
+        }
 
         return match ($message) {
             'Fleet not placed' => ['FLEET_NOT_PLACED', 422],

--- a/tests/Functional/GameApiFunModeTest.php
+++ b/tests/Functional/GameApiFunModeTest.php
@@ -37,7 +37,7 @@ final class GameApiFunModeTest extends WebTestCase
         self::assertSame(['used' => 0, 'limit' => 1], $view['weapons']['airRaid']);
 
         // torpedo: full turn — results + AI response + turn back to player
-        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 5, 'direction' => 'E']));
+        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 0, 'direction' => 'E']));
         self::assertResponseIsSuccessful();
         $torpedo = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
         self::assertCount(10, $torpedo['results']);
@@ -66,6 +66,12 @@ final class GameApiFunModeTest extends WebTestCase
         $view = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
         self::assertSame(['used' => 1, 'limit' => 1], $view['weapons']['airRaid']);
         self::assertSame(['used' => 1, 'limit' => 3], $view['weapons']['sonar']);
+
+        // torpeda z wody → 422 TORPEDO_LAUNCH_INVALID (start musi być na niezatopionym statku)
+        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 4, 'y' => 4, 'direction' => 'E']));
+        self::assertResponseStatusCodeSame(422);
+        $err = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('TORPEDO_LAUNCH_INVALID', $err['error']['code']);
     }
 
     public function testWeaponsRejectedInClassicGame(): void
@@ -79,7 +85,7 @@ final class GameApiFunModeTest extends WebTestCase
         self::assertResponseIsSuccessful();
 
         // classic → torpeda niedostępna (422 z ExceptionSubscriber)
-        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 5, 'direction' => 'E']));
+        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 0, 'direction' => 'E']));
         self::assertResponseStatusCodeSame(422);
 
         // classic → sonar niedostępny

--- a/tests/Unit/GameFireTorpedoTest.php
+++ b/tests/Unit/GameFireTorpedoTest.php
@@ -30,8 +30,11 @@ final class GameFireTorpedoTest extends TestCase
             $this->assertContains($r['result'], ['hit', 'sunk', 'miss', 'duplicate']);
         }
 
-        // Ponowne odpalenie — wszystkie powinny być duplicate
-        $resultsDup = $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+        // Ponowne odpalenie w ten sam wiersz — wszystkie duplicate.
+        // Start z (6,0): w tym teście (fallback bez floty przeciwnika) pierwsza
+        // torpeda zatopiła własnego 4-masztowca na (0,0), a wyrzutnią może być
+        // tylko niezatopiony statek; trójmasztowiec (6,0)-(6,2) wciąż pływa.
+        $resultsDup = $game->fireTorpedo(new Coordinate(6, 0), Direction::E);
         foreach ($resultsDup as $r) {
             $this->assertSame('duplicate', $r['result']);
         }
@@ -53,5 +56,55 @@ final class GameFireTorpedoTest extends TestCase
             $this->assertSame(9 - $i, $r['y']);
             $this->assertContains($r['result'], ['hit', 'sunk', 'miss', 'duplicate']);
         }
+    }
+
+    public function testTorpedoCannotBeLaunchedFromWater(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Torpedo must be launched from an unsunk ship');
+        // (1,1) to woda — 4-masztowiec stoi w wierszu 0, trójmasztowiec w wierszu 2
+        $game->fireTorpedo(new Coordinate(1, 1), Direction::E);
+    }
+
+    public function testTorpedoCannotBeLaunchedFromSunkShip(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+
+        // przeciwnik zatapia jedynkę gracza na (0,6)
+        $game->fireOpponentShot(new Coordinate(0, 6));
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Torpedo must be launched from an unsunk ship');
+        $game->fireTorpedo(new Coordinate(0, 6), Direction::E);
+    }
+
+    public function testTorpedoCanBeLaunchedFromDamagedButUnsunkShip(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+
+        // przeciwnik trafia 4-masztowiec gracza na (0,0) — uszkodzony, ale pływa
+        $game->fireOpponentShot(new Coordinate(0, 0));
+
+        $results = $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+        $this->assertCount(10, $results);
+    }
+
+    public function testFailedLaunchDoesNotConsumeTorpedo(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+
+        try {
+            $game->fireTorpedo(new Coordinate(1, 1), Direction::E); // woda
+        } catch (\DomainException) {
+            // oczekiwane
+        }
+
+        $this->assertSame(0, $game->weaponsState()['torpedo']['used']);
     }
 }

--- a/tests/Unit/GameWeaponLimitsTest.php
+++ b/tests/Unit/GameWeaponLimitsTest.php
@@ -33,9 +33,9 @@ it('odrzuca sonar w klasycznym rulesecie', function () {
 
 it('egzekwuje limit torped na grę', function () {
     $game = funGame();
-    $game->fireTorpedo(new Coordinate(0, 5), Direction::E);
-    $game->fireTorpedo(new Coordinate(0, 7), Direction::E);
-    $game->fireTorpedo(new Coordinate(0, 9), Direction::E);
+    $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+    $game->fireTorpedo(new Coordinate(0, 2), Direction::E);
+    $game->fireTorpedo(new Coordinate(6, 0), Direction::E);
 })->throws(DomainException::class, 'Torpedo limit reached');
 
 it('egzekwuje limit sonarów na grę', function () {
@@ -54,7 +54,7 @@ it('egzekwuje limit nalotów na grę', function () {
 
 it('raportuje stan broni: użycia i limity', function () {
     $game = funGame();
-    $game->fireTorpedo(new Coordinate(0, 5), Direction::E);
+    $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
     $game->sonarPing(new Coordinate(5, 5));
 
     expect($game->weaponsState())->toBe([


### PR DESCRIPTION
Nowa reguła gameplay (pomysł z rozgrywki 2026-07-11): **torpeda musi być odpalona z pozycji własnego, niezatopionego statku** — pozycje żywej floty wyznaczają dostępne linie ostrzału, więc torpeda przestaje być darmowym skanem dowolnego wiersza, a utrata statków realnie ogranicza opcje ofensywne.

## Reguła

- start torpedy = komórka statku gracza, który **nie został zatopiony** (uszkodzony, ale pływający — może strzelać)
- tor bez zmian: od tej pozycji w wybranym kierunku po planszy przeciwnika
- nieudana walidacja (woda / zatopiony statek) → **422 `TORPEDO_LAUNCH_INVALID`** i **nie zużywa limitu** (wydzielone `assertWeaponAvailable` z `consumeWeapon`)

## UI

Torpedę odpala się teraz klikiem we **własną planszę**: w trybie torpedy legalne wyrzutnie są podświetlone (zielony pierścień), hover na wyrzutni rysuje tor na planszy przeciwnika, a plansza wroga jest w tym trybie nieaktywna. Hint zaktualizowany.

## Weryfikacja

- Pest: **80 passed** (nowe: z wody → wyjątek, z zatopionego → wyjątek, z uszkodzonego-niezatopionego → OK, nieudany start nie zużywa limitu, funkcjonalny 422 z kodem)
- ciekawostka testowa: w testach unit bez floty przeciwnika (legacy fallback) pierwsza torpeda zatapia… własny statek-wyrzutnię, więc druga startuje z innego — udokumentowane w teście
- PHPStan / cs-fixer / vue-tsc czyste; przeklikane w przeglądarce (podświetlenie wyrzutni, podgląd toru, animacja, licznik)

Uwaga do #22: gdy AI dostanie bronie, ta sama reguła ograniczy jego torpedy (pozycje floty AI są znane silnikowi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)