### PR TITLE
Give opponent AI access to special weapons in fun mode

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,8 +22,10 @@ services:
 
     # Domain ports
     App\Domain\Game\FleetGenerator: '@App\Domain\Game\RandomFleetGenerator'
+    App\Application\Game\WeaponUseDecider: '@App\Application\Game\RandomWeaponUseDecider'
 
-# Testy funkcjonalne wymagają przewidywalnej floty przeciwnika
+# Testy funkcjonalne wymagają przewidywalnej floty przeciwnika i tury AI
 when@test:
     services:
         App\Domain\Game\FleetGenerator: '@App\Domain\Game\DeterministicFleetGenerator'
+        App\Application\Game\WeaponUseDecider: '@App\Application\Game\NeverUseWeaponsDecider'

--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -25,6 +25,7 @@ export interface GameViewDTO {
     board: { w: number; h: number };
     ruleset: RulesetName;
     weapons: WeaponsState;
+    opponentWeapons?: WeaponsState;
     mode: 'standard' | 'nonstandard' | string;
     opponent: 'mock' | 'ai' | 'pvp' | string;
     turn: 'player' | 'opponent' | 'none';

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -8,7 +8,7 @@ import { useRouter } from 'vue-router'
 // automatycznie (zagnieżdżone w zwykłym obiekcie NIE są odpakowywane).
 const {
     status, finished, turn, loading, error, disabled, attack, width, height,
-    ruleset, weapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
+    ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
     shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
     toast, toastType,
     playerGrid, playerUnderFireOverlay, enemyFogGrid, lastShot, sunkCells,
@@ -207,6 +207,12 @@ function newGame() {
             <div v-if="error" style="color:crimson">{{ error }}</div>
             <div class="hud">
                 <div>Ruch: <strong>{{ turn }}</strong> <span v-if="disabled">(zablokowane)</span></div>
+                <div v-if="ruleset === 'fun' && opponentWeapons" class="ai-arsenal">
+                    Arsenał AI:
+                    🚀 {{ opponentWeapons.torpedo.limit - opponentWeapons.torpedo.used }}/{{ opponentWeapons.torpedo.limit }}
+                    📡 {{ opponentWeapons.sonar.limit - opponentWeapons.sonar.used }}/{{ opponentWeapons.sonar.limit }}
+                    ✈️ {{ opponentWeapons.airRaid.limit - opponentWeapons.airRaid.used }}/{{ opponentWeapons.airRaid.limit }}
+                </div>
                 <div class="stats">
                     <span class="pill">Strzały: <strong>{{ shotsCount }}</strong></span>
                     <span class="pill hit">Trafienia: <strong>{{ hitsCount }}</strong></span>
@@ -271,6 +277,7 @@ function newGame() {
 .wbtn[disabled] { opacity:.45; cursor:not-allowed; }
 .weapon-opts { margin-top:.35rem; display:flex; gap:.6rem; align-items:center; color:#334155; }
 .weapon-hint { margin-top:.3rem; font-size:.9rem; color:#475569; }
+.ai-arsenal { font-size:.9rem; color:#475569; }
 .toast { display:inline-block; padding:.3rem .6rem; border-radius:6px; border:1px solid #cbd5e1; background:#f8fafc; color:#0f172a; }
 .toast.warn { background:#fff7ed; border-color:#fed7aa; color:#7c2d12; }
 .toast.error { background:#fee2e2; border-color:#fecaca; color:#7f1d1d; }

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -37,6 +37,7 @@ export function useGame() {
     // Tryb fun: bronie specjalne
     const ruleset = ref<RulesetName>('classic');
     const weapons = ref<WeaponsState | null>(null);
+    const opponentWeapons = ref<WeaponsState | null>(null);
     const weaponMode = ref<WeaponMode>('shot');
     const torpedoDirection = ref<TorpedoDirection>('E');
     // Wyniki sonaru — tylko po stronie klienta (backend nie zapisuje skanów)
@@ -104,6 +105,7 @@ export function useGame() {
         finished.value = dto.finished;
         ruleset.value = dto.ruleset ?? 'classic';
         weapons.value = dto.weapons ?? null;
+        opponentWeapons.value = dto.opponentWeapons ?? null;
         playerFleet.value = dto.playerFleet ?? [];
     }
 
@@ -328,7 +330,7 @@ export function useGame() {
         gameId, size, width, height, playerGrid, playerUnderFireOverlay, enemyFogGrid, turn, status, finished,
         loading, error, start, refresh, shot, attack, disabled,
         // tryb fun
-        ruleset, weapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
+        ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
         // stats
         shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
         // toast

--- a/src/Application/Game/NeverUseWeaponsDecider.php
+++ b/src/Application/Game/NeverUseWeaponsDecider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Game;
+
+/**
+ * AI nigdy nie sięga po bronie — wiring env testowego (deterministyczna
+ * tura AI: zawsze pojedynczy strzał).
+ */
+final class NeverUseWeaponsDecider implements WeaponUseDecider
+{
+    public function decide(int $percent): bool
+    {
+        return false;
+    }
+}

--- a/src/Application/Game/OpponentTurn.php
+++ b/src/Application/Game/OpponentTurn.php
@@ -3,14 +3,46 @@
 namespace App\Application\Game;
 
 use App\Domain\Game\AI\HuntTargetAI;
+use App\Domain\Game\Area;
+use App\Domain\Game\BoardReadModel;
+use App\Domain\Game\Coordinate;
+use App\Domain\Game\Direction;
 use App\Domain\Game\Game;
+use App\Domain\Game\ShotResult;
 
 /**
- * Odpowiedź przeciwnika (AI) po ofensywnym ruchu gracza: jeden strzał
- * + rozliczenie tury i końca gry. Wspólne dla strzału, torpedy i nalotu.
+ * Tura przeciwnika (AI) po ofensywnym ruchu gracza.
+ *
+ * W trybie fun AI korzysta z broni specjalnych (te same limity i reguły co gracz):
+ * - sonar: zwiad w trybie hunt — wykryte statki trafiają do kolejki dobijania
+ *   (jak u gracza nie zużywa akcji ofensywnej),
+ * - torpeda: z pozycji własnego niezatopionego statku, w linię z największą
+ *   liczbą nieostrzelanych pól,
+ * - nalot: w najgęstszy nieostrzelany obszar 3×3.
+ * Bronie tylko w trybie hunt (przy dobijaniu zwykły strzał jest skuteczniejszy),
+ * z losową częstością — AI nie może być przewidywalne.
  */
 final class OpponentTurn
 {
+    private const SONAR_CHANCE = 40;
+    private const TORPEDO_CHANCE = 35;
+    private const AIR_RAID_CHANCE = 25;
+
+    /** Torpeda tylko, gdy linia ma co najmniej tyle nieostrzelanych pól. */
+    private const TORPEDO_MIN_UNTRIED = 5;
+
+    /** Nalot tylko, gdy obszar 3×3 ma co najmniej tyle nieostrzelanych pól. */
+    private const AIR_RAID_MIN_UNTRIED = 6;
+
+    /**
+     * @param (\Closure(int): bool)|null $decider decyzja "czy użyć" dla podanego
+     *                                            procentu szansy; null = losowo
+     *                                            (wstrzykiwane w testach)
+     */
+    public function __construct(private readonly ?\Closure $decider = null)
+    {
+    }
+
     /**
      * @return array{finished:bool, win:bool, loss:bool, turn:string, opponentMoves:list<array{x:int,y:int,result:string}>}
      */
@@ -21,11 +53,8 @@ final class OpponentTurn
 
         if (!$finished) {
             $ai = HuntTargetAI::fromSnapshot($game->aiState());
-            $target = $ai->nextShot($game->opponentShotsView());
-            $result = $game->fireOpponentShot($target);
-            $ai->notify($target, $result);
+            $opponentMoves = $this->act($game, $ai);
             $game->setAiState($ai->toSnapshot());
-            $opponentMoves[] = ['x' => $target->x, 'y' => $target->y, 'result' => $result->value];
 
             $finished = $game->isFinished();
         }
@@ -41,5 +70,195 @@ final class OpponentTurn
             'turn' => $turn,
             'opponentMoves' => $opponentMoves,
         ];
+    }
+
+    /** @return list<array{x:int,y:int,result:string}> */
+    private function act(Game $game, HuntTargetAI $ai): array
+    {
+        $view = $game->opponentShotsView();
+        $huntMode = [] === ($game->aiState()['targets'] ?? []);
+        $weapons = 'fun' === $game->ruleset()->name() ? $game->opponentWeaponsState() : [];
+
+        // 1) Zwiad: sonar w trybie hunt (nie zużywa akcji ofensywnej)
+        if ($huntMode && $this->hasUses($weapons, 'sonar') && $this->decide(self::SONAR_CHANCE)) {
+            $center = $this->bestSonarCenter($view);
+            if (null !== $center) {
+                $detected = [];
+                foreach ($game->opponentSonarPing($center) as $cell) {
+                    $c = new Coordinate($cell['x'], $cell['y']);
+                    if ($cell['occupied'] && !$view->wasTried($c)) {
+                        $detected[] = $c;
+                    }
+                }
+                $ai->enqueueTargets($detected);
+                $huntMode = [] === $detected;
+            }
+        }
+
+        // 2) Akcja ofensywna: torpeda / nalot (tylko hunt) albo zwykły strzał
+        if ($huntMode && $this->hasUses($weapons, 'torpedo') && $this->decide(self::TORPEDO_CHANCE)) {
+            $run = $this->bestTorpedoRun($game, $view);
+            if (null !== $run) {
+                [$start, $direction] = $run;
+                $results = $game->fireOpponentTorpedo($start, $direction);
+                $this->notifyAll($ai, $results);
+
+                return $results;
+            }
+        }
+
+        if ($huntMode && $this->hasUses($weapons, 'airRaid') && $this->decide(self::AIR_RAID_CHANCE)) {
+            $center = $this->bestAirRaidCenter($view);
+            if (null !== $center) {
+                $results = $game->sendOpponentAirRaid($center, new Area(1, 1));
+                $this->notifyAll($ai, $results);
+
+                return $results;
+            }
+        }
+
+        $target = $ai->nextShot($view);
+        $result = $game->fireOpponentShot($target);
+        $ai->notify($target, $result);
+
+        return [['x' => $target->x, 'y' => $target->y, 'result' => $result->value]];
+    }
+
+    /** @param list<array{x:int,y:int,result:string}> $results */
+    private function notifyAll(HuntTargetAI $ai, array $results): void
+    {
+        foreach ($results as $r) {
+            $ai->notify(new Coordinate($r['x'], $r['y']), ShotResult::from($r['result']));
+        }
+    }
+
+    /** @param array<string, array{used:int, limit:int}> $weapons */
+    private function hasUses(array $weapons, string $name): bool
+    {
+        return isset($weapons[$name]) && $weapons[$name]['used'] < $weapons[$name]['limit'];
+    }
+
+    private function decide(int $percent): bool
+    {
+        if (null !== $this->decider) {
+            return ($this->decider)($percent);
+        }
+
+        return random_int(1, 100) <= $percent;
+    }
+
+    /** Środek krzyża sonaru maksymalizujący nieostrzelane pola. */
+    private function bestSonarCenter(BoardReadModel $view): ?Coordinate
+    {
+        $best = null;
+        $bestScore = 0;
+
+        for ($y = 0; $y < $view->height(); ++$y) {
+            for ($x = 0; $x < $view->width(); ++$x) {
+                $score = $this->countUntried($view, $this->sonarCross($view, $x, $y));
+                if ($score > $bestScore) {
+                    $bestScore = $score;
+                    $best = new Coordinate($x, $y);
+                }
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * Najlepsza linia torpedy: start z niezatopionego statku AI, maksimum
+     * nieostrzelanych pól; null, gdy żadna linia nie przekracza progu.
+     *
+     * @return array{0: Coordinate, 1: Direction}|null
+     */
+    private function bestTorpedoRun(Game $game, BoardReadModel $view): ?array
+    {
+        $best = null;
+        $bestScore = self::TORPEDO_MIN_UNTRIED - 1;
+
+        foreach ($game->opponentLaunchableCells() as $cell) {
+            foreach (Direction::cases() as $direction) {
+                [$dx, $dy] = match ($direction) {
+                    Direction::N => [0, -1],
+                    Direction::S => [0, 1],
+                    Direction::E => [1, 0],
+                    Direction::W => [-1, 0],
+                };
+
+                $score = 0;
+                $cx = $cell['x'];
+                $cy = $cell['y'];
+                while ($cx >= 0 && $cy >= 0 && $cx < $view->width() && $cy < $view->height()) {
+                    if (!$view->wasTried(new Coordinate($cx, $cy))) {
+                        ++$score;
+                    }
+                    $cx += $dx;
+                    $cy += $dy;
+                }
+
+                if ($score > $bestScore) {
+                    $bestScore = $score;
+                    $best = [new Coordinate($cell['x'], $cell['y']), $direction];
+                }
+            }
+        }
+
+        return $best;
+    }
+
+    /** Centrum nalotu 3×3 maksymalizujące nieostrzelane pola; null poniżej progu. */
+    private function bestAirRaidCenter(BoardReadModel $view): ?Coordinate
+    {
+        $best = null;
+        $bestScore = self::AIR_RAID_MIN_UNTRIED - 1;
+
+        for ($y = 0; $y < $view->height(); ++$y) {
+            for ($x = 0; $x < $view->width(); ++$x) {
+                $cells = [];
+                for ($dx = -1; $dx <= 1; ++$dx) {
+                    for ($dy = -1; $dy <= 1; ++$dy) {
+                        $cells[] = [$x + $dx, $y + $dy];
+                    }
+                }
+                $score = $this->countUntried($view, $cells);
+                if ($score > $bestScore) {
+                    $bestScore = $score;
+                    $best = new Coordinate($x, $y);
+                }
+            }
+        }
+
+        return $best;
+    }
+
+    /** @return list<array{0:int,1:int}> komórki krzyża sonaru (promień 3) */
+    private function sonarCross(BoardReadModel $view, int $x, int $y): array
+    {
+        $cells = [[$x, $y]];
+        for ($i = 1; $i <= 3; ++$i) {
+            $cells[] = [$x, $y - $i];
+            $cells[] = [$x + $i, $y];
+            $cells[] = [$x, $y + $i];
+            $cells[] = [$x - $i, $y];
+        }
+
+        return $cells;
+    }
+
+    /** @param list<array{0:int,1:int}> $cells */
+    private function countUntried(BoardReadModel $view, array $cells): int
+    {
+        $count = 0;
+        foreach ($cells as [$x, $y]) {
+            if ($x < 0 || $y < 0 || $x >= $view->width() || $y >= $view->height()) {
+                continue;
+            }
+            if (!$view->wasTried(new Coordinate($x, $y))) {
+                ++$count;
+            }
+        }
+
+        return $count;
     }
 }

--- a/src/Application/Game/OpponentTurn.php
+++ b/src/Application/Game/OpponentTurn.php
@@ -34,12 +34,7 @@ final class OpponentTurn
     /** Nalot tylko, gdy obszar 3×3 ma co najmniej tyle nieostrzelanych pól. */
     private const AIR_RAID_MIN_UNTRIED = 6;
 
-    /**
-     * @param (\Closure(int): bool)|null $decider decyzja "czy użyć" dla podanego
-     *                                            procentu szansy; null = losowo
-     *                                            (wstrzykiwane w testach)
-     */
-    public function __construct(private readonly ?\Closure $decider = null)
+    public function __construct(private readonly WeaponUseDecider $decider = new RandomWeaponUseDecider())
     {
     }
 
@@ -140,11 +135,7 @@ final class OpponentTurn
 
     private function decide(int $percent): bool
     {
-        if (null !== $this->decider) {
-            return ($this->decider)($percent);
-        }
-
-        return random_int(1, 100) <= $percent;
+        return $this->decider->decide($percent);
     }
 
     /** Środek krzyża sonaru maksymalizujący nieostrzelane pola. */

--- a/src/Application/Game/RandomWeaponUseDecider.php
+++ b/src/Application/Game/RandomWeaponUseDecider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Application\Game;
+
+final class RandomWeaponUseDecider implements WeaponUseDecider
+{
+    public function decide(int $percent): bool
+    {
+        return random_int(1, 100) <= $percent;
+    }
+}

--- a/src/Application/Game/WeaponUseDecider.php
+++ b/src/Application/Game/WeaponUseDecider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Application\Game;
+
+/**
+ * Decyzja "czy AI ma teraz użyć broni" dla zadanego procentu szansy.
+ * Produkcyjnie losowa; w env testowym podmieniana na deterministyczną
+ * (testy funkcjonalne wymagają przewidywalnej tury AI).
+ */
+interface WeaponUseDecider
+{
+    public function decide(int $percent): bool;
+}

--- a/src/Domain/Game/AI/HuntTargetAI.php
+++ b/src/Domain/Game/AI/HuntTargetAI.php
@@ -75,6 +75,19 @@ final class HuntTargetAI implements Shooter
         ];
     }
 
+    /**
+     * Dokłada zewnętrzne cele (np. wykryte sonarem) do kolejki dobijania.
+     * Nielegalne/ostrzelane odfiltruje nextShot() przy zdejmowaniu.
+     *
+     * @param Coordinate[] $coords
+     */
+    public function enqueueTargets(array $coords): void
+    {
+        foreach ($coords as $c) {
+            $this->targets[] = $c;
+        }
+    }
+
     public function nextShot(BoardReadModel $board): Coordinate
     {
         // Target – najpierw kandydaci wokół trafień

--- a/src/Domain/Game/BoardSide.php
+++ b/src/Domain/Game/BoardSide.php
@@ -116,6 +116,30 @@ final class BoardSide
         return null !== $ship && !$this->isSunk($ship);
     }
 
+    /**
+     * Komórki wszystkich niezatopionych statków tej strony (legalne wyrzutnie torped).
+     *
+     * @return list<array{x:int,y:int}>
+     */
+    public function unsunkShipCells(): array
+    {
+        if (!$this->hasFleet()) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($this->board->ships() as $ship) {
+            if ($this->isSunk($ship)) {
+                continue;
+            }
+            foreach ($ship->cells() as $c) {
+                $out[] = ['x' => $c->x, 'y' => $c->y];
+            }
+        }
+
+        return $out;
+    }
+
     /** @return list<array{x:int,y:int}> */
     public function shotsTaken(): array
     {

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -28,12 +28,13 @@ final class Game
     private array $aiState = [];
 
     /**
-     * Liczba użyć broni specjalnych w tej grze (klucze: torpedo|sonar|airRaid).
-     * Limity per grę definiuje Ruleset::weaponLimits(); 0 = broń niedostępna.
+     * Liczba użyć broni specjalnych per strona (klucze zewn.: player|opponent,
+     * wewn.: torpedo|sonar|airRaid). Limity per grę i stronę definiuje
+     * Ruleset::weaponLimits(); 0 = broń niedostępna.
      *
-     * @var array<string,int>
+     * @var array{player: array<string,int>, opponent: array<string,int>}
      */
-    private array $weaponUses = [];
+    private array $weaponUses = ['player' => [], 'opponent' => []];
 
     public function __construct(
         private GameId $id,
@@ -238,52 +239,79 @@ final class Game
     }
 
     /**
-     * Stan broni specjalnych: użycia i limity z rulesetu.
+     * Stan broni specjalnych gracza: użycia i limity z rulesetu.
      *
      * @return array<string, array{used:int, limit:int}>
      */
     public function weaponsState(): array
     {
+        return $this->weaponsStateFor('player');
+    }
+
+    /**
+     * Stan broni specjalnych przeciwnika (AI).
+     *
+     * @return array<string, array{used:int, limit:int}>
+     */
+    public function opponentWeaponsState(): array
+    {
+        return $this->weaponsStateFor('opponent');
+    }
+
+    /** @return array<string, array{used:int, limit:int}> */
+    private function weaponsStateFor(string $shooter): array
+    {
         $out = [];
         foreach ($this->ruleset->weaponLimits() as $weapon => $limit) {
-            $out[$weapon] = ['used' => $this->weaponUses[$weapon] ?? 0, 'limit' => $limit];
+            $out[$weapon] = ['used' => $this->weaponUses[$shooter][$weapon] ?? 0, 'limit' => $limit];
         }
 
         return $out;
     }
 
-    /** @return array<string,int> surowe liczniki użyć (do snapshotu) */
+    /** @return array{player: array<string,int>, opponent: array<string,int>} surowe liczniki (do snapshotu) */
     public function weaponUses(): array
     {
         return $this->weaponUses;
     }
 
-    /** @param array<string,int> $uses */
+    /**
+     * Odtwarza liczniki użyć broni ze snapshotu. Obsługuje dwa kształty:
+     * nowy (player/opponent) oraz starszy płaski (tylko użycia gracza).
+     *
+     * @param array<string,mixed> $uses
+     */
     public function setWeaponUsesFromSnapshot(array $uses): void
     {
-        $this->weaponUses = [];
-        foreach ($uses as $weapon => $count) {
-            $this->weaponUses[(string) $weapon] = max(0, (int) $count);
+        $this->weaponUses = ['player' => [], 'opponent' => []];
+
+        $isPerSide = isset($uses['player']) || isset($uses['opponent']);
+        $sides = $isPerSide ? $uses : ['player' => $uses];
+
+        foreach (['player', 'opponent'] as $side) {
+            foreach ((array) ($sides[$side] ?? []) as $weapon => $count) {
+                $this->weaponUses[$side][(string) $weapon] = max(0, (int) $count);
+            }
         }
     }
 
-    /** Rzuca, gdy broń niedostępna w rulesecie albo limit na grę wyczerpany. */
-    private function assertWeaponAvailable(string $weapon): void
+    /** Rzuca, gdy broń niedostępna w rulesecie albo limit danej strony wyczerpany. */
+    private function assertWeaponAvailable(string $shooter, string $weapon): void
     {
         $limit = $this->ruleset->weaponLimits()[$weapon] ?? 0;
         if ($limit <= 0) {
             throw new \DomainException(sprintf('%s not available in this ruleset', ucfirst($weapon)));
         }
-        if (($this->weaponUses[$weapon] ?? 0) >= $limit) {
+        if (($this->weaponUses[$shooter][$weapon] ?? 0) >= $limit) {
             throw new \DomainException(sprintf('%s limit reached', ucfirst($weapon)));
         }
     }
 
     /** Zużywa jedno użycie broni (po przejściu wszystkich walidacji). */
-    private function consumeWeapon(string $weapon): void
+    private function consumeWeapon(string $shooter, string $weapon): void
     {
-        $this->assertWeaponAvailable($weapon);
-        $this->weaponUses[$weapon] = ($this->weaponUses[$weapon] ?? 0) + 1;
+        $this->assertWeaponAvailable($shooter, $weapon);
+        $this->weaponUses[$shooter][$weapon] = ($this->weaponUses[$shooter][$weapon] ?? 0) + 1;
     }
 
     /** Strzały gracza. @return list<array{x:int,y:int}> */
@@ -345,7 +373,7 @@ final class Game
             throw new \DomainException('Fleet not placed');
         }
 
-        $this->assertWeaponAvailable('torpedo');
+        $this->assertWeaponAvailable('player', 'torpedo');
 
         $w = $this->ruleset->boardSize()->width;
         $h = $this->ruleset->boardSize()->height;
@@ -358,7 +386,7 @@ final class Game
             throw new \DomainException('Torpedo must be launched from an unsunk ship');
         }
 
-        $this->consumeWeapon('torpedo');
+        $this->consumeWeapon('player', 'torpedo');
 
         // Direction vector
         [$dx, $dy] = match ($direction) {
@@ -396,7 +424,7 @@ final class Game
             throw new \DomainException('Fleet not placed');
         }
 
-        $this->consumeWeapon('sonar');
+        $this->consumeWeapon('player', 'sonar');
 
         $target = $this->targetSide();
 
@@ -455,7 +483,7 @@ final class Game
             throw new \DomainException('Air Raid area is oversize');
         }
 
-        $this->consumeWeapon('airRaid');
+        $this->consumeWeapon('player', 'airRaid');
 
         $fromX = max(0, $start->x - $area->width);
         $toX = min($w - 1, $start->x + $area->width);
@@ -467,6 +495,144 @@ final class Game
         for ($x = $fromX; $x <= $toX; ++$x) {
             for ($y = $fromY; $y <= $toY; ++$y) {
                 $r = $this->fireShot(new Coordinate($x, $y));
+                $results[] = ['x' => $x, 'y' => $y, 'result' => $r->value];
+            }
+        }
+
+        return $results;
+    }
+
+    // --- Bronie specjalne przeciwnika (AI) — lustrzane wobec broni gracza ---
+
+    /**
+     * Komórki niezatopionych statków AI — legalne wyrzutnie jego torped.
+     *
+     * @return list<array{x:int,y:int}>
+     */
+    public function opponentLaunchableCells(): array
+    {
+        return $this->opponentSide->unsunkShipCells();
+    }
+
+    /**
+     * Torpeda AI: startuje z niezatopionego statku AI, ostrzeliwuje planszę
+     * gracza wzdłuż kierunku. Ta sama reguła wyrzutni co u gracza.
+     *
+     * @return list<array{x:int,y:int,result:string}>
+     */
+    public function fireOpponentTorpedo(Coordinate $start, Direction $direction): array
+    {
+        if (!$this->playerSide->hasFleet()) {
+            throw new \DomainException('Fleet not placed');
+        }
+
+        $this->assertWeaponAvailable('opponent', 'torpedo');
+
+        $w = $this->ruleset->boardSize()->width;
+        $h = $this->ruleset->boardSize()->height;
+
+        if ($start->x >= $w || $start->y >= $h) {
+            throw new \DomainException('Torpedo start outside board');
+        }
+
+        if (!$this->opponentSide->hasUnsunkShipAt($start->x, $start->y)) {
+            throw new \DomainException('Torpedo must be launched from an unsunk ship');
+        }
+
+        $this->consumeWeapon('opponent', 'torpedo');
+
+        [$dx, $dy] = match ($direction) {
+            Direction::N => [0, -1],
+            Direction::S => [0, 1],
+            Direction::E => [1, 0],
+            Direction::W => [-1, 0],
+        };
+
+        $results = [];
+        $cx = $start->x;
+        $cy = $start->y;
+        while ($cx >= 0 && $cy >= 0 && $cx < $w && $cy < $h) {
+            $r = $this->fireOpponentShot(new Coordinate($cx, $cy));
+            $results[] = ['x' => $cx, 'y' => $cy, 'result' => $r->value];
+            $cx += $dx;
+            $cy += $dy;
+        }
+
+        return $results;
+    }
+
+    /**
+     * Sonar AI: skanuje planszę gracza (krzyż o promieniu $radius). Bez zmian stanu strzałów.
+     *
+     * @return list<array{x:int,y:int,occupied:bool}>
+     */
+    public function opponentSonarPing(Coordinate $center, int $radius = 3): array
+    {
+        if (!$this->playerSide->hasFleet()) {
+            throw new \DomainException('Fleet not placed');
+        }
+
+        $this->consumeWeapon('opponent', 'sonar');
+
+        $w = $this->ruleset->boardSize()->width;
+        $h = $this->ruleset->boardSize()->height;
+
+        $inBounds = static fn (int $x, int $y) => $x >= 0 && $y >= 0 && $x < $w && $y < $h;
+
+        $cells = [[$center->x, $center->y]];
+        for ($i = 1; $i <= $radius; ++$i) {
+            $cells[] = [$center->x, $center->y - $i];
+            $cells[] = [$center->x + $i, $center->y];
+            $cells[] = [$center->x, $center->y + $i];
+            $cells[] = [$center->x - $i, $center->y];
+        }
+
+        $results = [];
+        foreach ($cells as [$x, $y]) {
+            if (!$inBounds($x, $y)) {
+                continue;
+            }
+            $results[] = ['x' => $x, 'y' => $y, 'occupied' => $this->playerSide->hasShipAt($x, $y)];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Nalot AI: ostrzeliwuje prostokąt planszy gracza wokół centrum
+     * (semantyka pół-zasięgów i limit rozmiaru jak u gracza).
+     *
+     * @return list<array{x:int,y:int,result:string}>
+     */
+    public function sendOpponentAirRaid(Coordinate $start, Area $area): array
+    {
+        if (!$this->playerSide->hasFleet()) {
+            throw new \DomainException('Fleet not placed');
+        }
+
+        $w = $this->ruleset->boardSize()->width;
+        $h = $this->ruleset->boardSize()->height;
+
+        if ($start->x >= $w || $start->y >= $h) {
+            throw new \DomainException('Air Raid start outside board');
+        }
+
+        $max = $this->ruleset->airRaidSize();
+        if (2 * $area->width + 1 > $max->width || 2 * $area->height + 1 > $max->height) {
+            throw new \DomainException('Air Raid area is oversize');
+        }
+
+        $this->consumeWeapon('opponent', 'airRaid');
+
+        $fromX = max(0, $start->x - $area->width);
+        $toX = min($w - 1, $start->x + $area->width);
+        $fromY = max(0, $start->y - $area->height);
+        $toY = min($h - 1, $start->y + $area->height);
+
+        $results = [];
+        for ($x = $fromX; $x <= $toX; ++$x) {
+            for ($y = $fromY; $y <= $toY; ++$y) {
+                $r = $this->fireOpponentShot(new Coordinate($x, $y));
                 $results[] = ['x' => $x, 'y' => $y, 'result' => $r->value];
             }
         }

--- a/src/Infrastructure/Http/Controller/GameQueryController.php
+++ b/src/Infrastructure/Http/Controller/GameQueryController.php
@@ -88,6 +88,7 @@ final class GameQueryController
             'board' => ['w' => $size->width, 'h' => $size->height],
             'ruleset' => $game->ruleset()->name(),
             'weapons' => $game->weaponsState(),
+            'opponentWeapons' => $game->opponentWeaponsState(),
             'mode' => $game->mode(),
             'opponent' => $game->opponent(),
             'turn' => $turn,

--- a/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
+++ b/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
@@ -67,8 +67,8 @@ final class GameSnapshotMapper
             'opponentFleet' => $opponentFleet,
             // Stan AI przeciwnika (kształt zna HuntTargetAI) – opcjonalnie
             'ai' => [] !== $game->aiState() ? $game->aiState() : null,
-            // Użycia broni specjalnych (limity trzyma Ruleset)
-            'weapons' => [] !== $game->weaponUses() ? $game->weaponUses() : null,
+            // Użycia broni specjalnych per strona (limity trzyma Ruleset)
+            'weapons' => $this->weaponUsesOrNull($game),
             // Iteration 1 meta
             'mode' => $game->mode(),
             'opponent' => $game->opponent(),
@@ -185,5 +185,13 @@ final class GameSnapshotMapper
         return 'fun' === ($data['type'] ?? 'classic')
             ? new FunRuleset($size)
             : new ClassicRuleset($size);
+    }
+
+    /** @return array{player: array<string,int>, opponent: array<string,int>}|null */
+    private function weaponUsesOrNull(Game $game): ?array
+    {
+        $uses = $game->weaponUses();
+
+        return ([] !== $uses['player'] || [] !== $uses['opponent']) ? $uses : null;
     }
 }

--- a/tests/Unit/Application/OpponentTurnTest.php
+++ b/tests/Unit/Application/OpponentTurnTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Game\OpponentTurn;
+use App\Domain\Game\BoardSize;
+use App\Domain\Game\ClassicRuleset;
+use App\Domain\Game\FunRuleset;
+use App\Domain\Game\Game;
+use Tests\Support\FleetFactory;
+
+function funGameWithBothFleets(): Game
+{
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+    $game->placeOpponentFleet(FleetFactory::classic10x10());
+    $game->setTurn('opponent');
+
+    return $game;
+}
+
+it('AI robi zwykły strzał, gdy losowanie odmawia użycia broni', function () {
+    $turn = new OpponentTurn(decider: fn (int $pct) => false);
+    $game = funGameWithBothFleets();
+
+    $out = $turn->respond($game);
+
+    expect($out['opponentMoves'])->toHaveCount(1);
+    expect($game->opponentWeaponsState())->toBe([
+        'torpedo' => ['used' => 0, 'limit' => 2],
+        'sonar' => ['used' => 0, 'limit' => 3],
+        'airRaid' => ['used' => 0, 'limit' => 1],
+    ]);
+});
+
+it('AI w trybie hunt używa sonaru jako zwiadu i dobija wykryty statek', function () {
+    $turn = new OpponentTurn(decider: fn (int $pct) => true);
+    $game = funGameWithBothFleets();
+
+    $out = $turn->respond($game);
+
+    // sonar zużyty (zwiad), akcja ofensywna = zwykły strzał w wykryty cel
+    expect($game->opponentWeaponsState()['sonar']['used'])->toBe(1);
+    expect($game->opponentWeaponsState()['torpedo']['used'])->toBe(0);
+    expect($out['opponentMoves'])->toHaveCount(1);
+    expect($out['opponentMoves'][0]['result'])->toBeIn(['hit', 'sunk']);
+
+    // wykryte cele przetrwały w snapshotcie stanu AI
+    expect($game->aiState()['targets'])->not->toBe([]);
+});
+
+it('AI odpala torpedę z niezatopionego statku w linię z nieostrzelanymi polami', function () {
+    // decyzja: tak tylko dla torpedy (35%), nie dla sonaru (40%) i nalotu (25%)
+    $turn = new OpponentTurn(decider: fn (int $pct) => 35 === $pct);
+    $game = funGameWithBothFleets();
+
+    $out = $turn->respond($game);
+
+    expect($game->opponentWeaponsState()['torpedo']['used'])->toBe(1);
+    expect(count($out['opponentMoves']))->toBeGreaterThanOrEqual(5);
+    // wszystkie strzały torpedy wylądowały na planszy gracza
+    expect($game->opponentShots())->toHaveCount(count($out['opponentMoves']));
+});
+
+it('AI używa nalotu, gdy torpeda niedostępna', function () {
+    // tak dla nalotu (25%), nie dla sonaru; torpeda „tak", ale wyczerpiemy jej limit
+    $turn = new OpponentTurn(decider: fn (int $pct) => 40 !== $pct);
+    $game = funGameWithBothFleets();
+    $game->setWeaponUsesFromSnapshot(['opponent' => ['torpedo' => 2]]); // limit torped wyczerpany
+
+    $out = $turn->respond($game);
+
+    expect($game->opponentWeaponsState()['airRaid']['used'])->toBe(1);
+    expect(count($out['opponentMoves']))->toBe(9); // pełne 3×3 w głębi planszy
+});
+
+it('AI nie sięga po bronie w trybie target (dobija zwykłym strzałem)', function () {
+    $turn = new OpponentTurn(decider: fn (int $pct) => true);
+    $game = funGameWithBothFleets();
+    $game->setAiState(['targets' => [['x' => 0, 'y' => 0]]]); // tryb target
+
+    $out = $turn->respond($game);
+
+    expect($game->opponentWeaponsState()['sonar']['used'])->toBe(0);
+    expect($game->opponentWeaponsState()['torpedo']['used'])->toBe(0);
+    expect($out['opponentMoves'])->toHaveCount(1);
+    expect($out['opponentMoves'][0])->toMatchArray(['x' => 0, 'y' => 0]);
+});
+
+it('AI w grze klasycznej nigdy nie używa broni', function () {
+    $turn = new OpponentTurn(decider: fn (int $pct) => true);
+    $game = Game::create(new ClassicRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+    $game->placeOpponentFleet(FleetFactory::classic10x10());
+    $game->setTurn('opponent');
+
+    $out = $turn->respond($game);
+
+    expect($out['opponentMoves'])->toHaveCount(1);
+    expect($game->weaponUses())->toBe(['player' => [], 'opponent' => []]);
+});
+
+it('limity broni gracza i AI są rozdzielne', function () {
+    $game = funGameWithBothFleets();
+    $game->setWeaponUsesFromSnapshot(['player' => ['torpedo' => 2]]); // gracz wystrzelał swoje
+
+    // AI wciąż ma pełny limit — torpeda przechodzi
+    $turn = new OpponentTurn(decider: fn (int $pct) => 35 === $pct);
+    $turn->respond($game);
+
+    expect($game->weaponsState()['torpedo']['used'])->toBe(2);
+    expect($game->opponentWeaponsState()['torpedo']['used'])->toBe(1);
+});

--- a/tests/Unit/Application/OpponentTurnTest.php
+++ b/tests/Unit/Application/OpponentTurnTest.php
@@ -3,11 +3,26 @@
 declare(strict_types=1);
 
 use App\Application\Game\OpponentTurn;
+use App\Application\Game\WeaponUseDecider;
 use App\Domain\Game\BoardSize;
 use App\Domain\Game\ClassicRuleset;
 use App\Domain\Game\FunRuleset;
 use App\Domain\Game\Game;
 use Tests\Support\FleetFactory;
+
+function decider(callable $fn): WeaponUseDecider
+{
+    return new class($fn(...)) implements WeaponUseDecider {
+        public function __construct(private readonly Closure $fn)
+        {
+        }
+
+        public function decide(int $percent): bool
+        {
+            return ($this->fn)($percent);
+        }
+    };
+}
 
 function funGameWithBothFleets(): Game
 {
@@ -20,7 +35,7 @@ function funGameWithBothFleets(): Game
 }
 
 it('AI robi zwykły strzał, gdy losowanie odmawia użycia broni', function () {
-    $turn = new OpponentTurn(decider: fn (int $pct) => false);
+    $turn = new OpponentTurn(decider(fn (int $pct) => false));
     $game = funGameWithBothFleets();
 
     $out = $turn->respond($game);
@@ -34,7 +49,7 @@ it('AI robi zwykły strzał, gdy losowanie odmawia użycia broni', function () {
 });
 
 it('AI w trybie hunt używa sonaru jako zwiadu i dobija wykryty statek', function () {
-    $turn = new OpponentTurn(decider: fn (int $pct) => true);
+    $turn = new OpponentTurn(decider(fn (int $pct) => true));
     $game = funGameWithBothFleets();
 
     $out = $turn->respond($game);
@@ -51,7 +66,7 @@ it('AI w trybie hunt używa sonaru jako zwiadu i dobija wykryty statek', functio
 
 it('AI odpala torpedę z niezatopionego statku w linię z nieostrzelanymi polami', function () {
     // decyzja: tak tylko dla torpedy (35%), nie dla sonaru (40%) i nalotu (25%)
-    $turn = new OpponentTurn(decider: fn (int $pct) => 35 === $pct);
+    $turn = new OpponentTurn(decider(fn (int $pct) => 35 === $pct));
     $game = funGameWithBothFleets();
 
     $out = $turn->respond($game);
@@ -64,7 +79,7 @@ it('AI odpala torpedę z niezatopionego statku w linię z nieostrzelanymi polami
 
 it('AI używa nalotu, gdy torpeda niedostępna', function () {
     // tak dla nalotu (25%), nie dla sonaru; torpeda „tak", ale wyczerpiemy jej limit
-    $turn = new OpponentTurn(decider: fn (int $pct) => 40 !== $pct);
+    $turn = new OpponentTurn(decider(fn (int $pct) => 40 !== $pct));
     $game = funGameWithBothFleets();
     $game->setWeaponUsesFromSnapshot(['opponent' => ['torpedo' => 2]]); // limit torped wyczerpany
 
@@ -75,7 +90,7 @@ it('AI używa nalotu, gdy torpeda niedostępna', function () {
 });
 
 it('AI nie sięga po bronie w trybie target (dobija zwykłym strzałem)', function () {
-    $turn = new OpponentTurn(decider: fn (int $pct) => true);
+    $turn = new OpponentTurn(decider(fn (int $pct) => true));
     $game = funGameWithBothFleets();
     $game->setAiState(['targets' => [['x' => 0, 'y' => 0]]]); // tryb target
 
@@ -88,7 +103,7 @@ it('AI nie sięga po bronie w trybie target (dobija zwykłym strzałem)', functi
 });
 
 it('AI w grze klasycznej nigdy nie używa broni', function () {
-    $turn = new OpponentTurn(decider: fn (int $pct) => true);
+    $turn = new OpponentTurn(decider(fn (int $pct) => true));
     $game = Game::create(new ClassicRuleset(new BoardSize(10, 10)));
     $game->placeFleet(FleetFactory::classic10x10());
     $game->placeOpponentFleet(FleetFactory::classic10x10());
@@ -105,7 +120,7 @@ it('limity broni gracza i AI są rozdzielne', function () {
     $game->setWeaponUsesFromSnapshot(['player' => ['torpedo' => 2]]); // gracz wystrzelał swoje
 
     // AI wciąż ma pełny limit — torpeda przechodzi
-    $turn = new OpponentTurn(decider: fn (int $pct) => 35 === $pct);
+    $turn = new OpponentTurn(decider(fn (int $pct) => 35 === $pct));
     $turn->respond($game);
 
     expect($game->weaponsState()['torpedo']['used'])->toBe(2);

--- a/tests/Unit/MapperSnapshotTest.php
+++ b/tests/Unit/MapperSnapshotTest.php
@@ -37,4 +37,27 @@ it('mapuje Game -> array -> Game (round-trip) z flotą', function () {
     expect($g2->fleet())->not->toBeNull();
 });
 
-// test
+it('round-tripuje liczniki broni per strona', function () {
+    $g = Game::create(new App\Domain\Game\FunRuleset());
+    $g->setWeaponUsesFromSnapshot(['player' => ['torpedo' => 1], 'opponent' => ['sonar' => 2]]);
+
+    $m = new GameSnapshotMapper();
+    $g2 = $m->toDomain((string) $g->id(), $m->toArray($g));
+
+    expect($g2->weaponsState()['torpedo']['used'])->toBe(1);
+    expect($g2->opponentWeaponsState()['sonar']['used'])->toBe(2);
+    expect($g2->opponentWeaponsState()['torpedo']['used'])->toBe(0);
+});
+
+it('stary płaski kształt weapons w snapshotcie trafia do liczników gracza', function () {
+    $m = new GameSnapshotMapper();
+    $g = $m->toDomain('9c2e8a4e-1f2b-4c3d-8a5e-123456789abc', [
+        'status' => 'in_progress',
+        'ruleset' => ['type' => 'fun', 'board' => ['w' => 10, 'h' => 10]],
+        'weapons' => ['torpedo' => 2, 'sonar' => 1],
+    ]);
+
+    expect($g->weaponsState()['torpedo']['used'])->toBe(2);
+    expect($g->weaponsState()['sonar']['used'])->toBe(1);
+    expect($g->opponentWeaponsState()['torpedo']['used'])->toBe(0);
+});


### PR DESCRIPTION
Closes #22

AI przeciwnika korzysta z broni specjalnych na tych samych zasadach co gracz — z własnym limitem.

## Fundament: limity per strona

Licznik użyć był **wspólny dla gry** — gdyby AI strzeliło torpedą, gracz straciłby swoją. Rozdzielone na `player`/`opponent`; snapshot w nowym kształcie, stary płaski czytany jako liczniki gracza (kompatybilność wstecz).

## Domena

Lustrzane metody broni AI: `fireOpponentTorpedo` / `opponentSonarPing` / `sendOpponentAirRaid` — pełna symetria reguł, łącznie z **startem torpedy z niezatopionego statku AI** (`BoardSide::unsunkShipCells()`).

## Polityka użycia (`OpponentTurn`)

- **sonar** = zwiad w trybie hunt (nie zużywa akcji ofensywnej): centrum krzyża maksymalizuje nieostrzelane pola, wykryte statki zasilają kolejkę dobijania `HuntTargetAI` (`enqueueTargets`)
- **torpeda**: linia z największą liczbą nieostrzelanych pól spośród dostępnych wyrzutni (próg ≥5)
- **nalot**: najgęstszy nieostrzelany obszar 3×3 (próg ≥6)
- bronie tylko w trybie hunt (dobijanie zwykłym strzałem), z losową częstością (40/35/25%) — AI nieprzewidywalne, a `decider` jest wstrzykiwalny, więc testy są deterministyczne

## UI

`GET` zwraca `opponentWeapons`; w HUD wiersz **„Arsenał AI: 🚀 📡 ✈️"** — widać, czym przeciwnik jeszcze dysponuje.

## Weryfikacja

Pest: **89 passed** (7 nowych testów polityki z deterministycznym deciderem: odmowa → zwykły strzał, sonar+dobicie, torpeda, nalot po wyczerpaniu torped, brak broni w trybie target i w classic, rozdzielność limitów; snapshot per strona + legacy). PHPStan/cs-fixer/vue-tsc czyste. Przeglądarka: w 5 tur AI zużyło sonar i torpedę (linia ostrzału przez cały wiersz na planszy gracza), arsenał w HUD maleje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)