### PR TITLE
Add diagonal torpedo directions with per-game limit and launch reveal

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -17,6 +17,8 @@ export interface WeaponsState {
     torpedo: WeaponState;
     sonar: WeaponState;
     airRaid: WeaponState;
+    // ile z torped może płynąć po przekątnej (podzbiór limitu torpedo)
+    torpedoDiagonal?: WeaponState;
 }
 
 export interface GameViewDTO {
@@ -75,7 +77,7 @@ export async function fireShot(id: string, x: number, y: number): Promise<ShotRe
 
 // --- bronie specjalne (tryb fun) ---
 
-export type TorpedoDirection = 'N' | 'E' | 'S' | 'W';
+export type TorpedoDirection = 'N' | 'NE' | 'E' | 'SE' | 'S' | 'SW' | 'W' | 'NW';
 
 export interface CellShotResult { x: number; y: number; result: 'hit' | 'miss' | 'sunk' | 'duplicate' }
 
@@ -85,6 +87,8 @@ export interface TurnOutcomeDTO {
     loss: boolean;
     turn: 'player' | 'opponent' | 'none';
     opponentMoves: CellShotResult[];
+    // torpeda AI zdradza wyrzutnię — pozycja statku przeciwnika
+    opponentTorpedoLaunch?: { x: number; y: number } | null;
 }
 
 export interface WeaponShotsResponse extends TurnOutcomeDTO {

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import GameGameBoard from './GameBoard.vue';
 import { useGame } from '../composables/useGame';
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 // Destrukturyzacja: ref-y stają się top-level, więc template odpakowuje je
@@ -30,7 +30,10 @@ const previewCells = computed<Set<string>>(() => {
 
     switch (weaponMode.value) {
         case 'torpedo': {
-            const [dx, dy] = { N: [0, -1], S: [0, 1], E: [1, 0], W: [-1, 0] }[torpedoDirection.value];
+            const [dx, dy] = {
+                N: [0, -1], NE: [1, -1], E: [1, 0], SE: [1, 1],
+                S: [0, 1], SW: [-1, 1], W: [-1, 0], NW: [-1, -1],
+            }[torpedoDirection.value];
             let cx = hc.x, cy = hc.y;
             while (cx >= 0 && cy >= 0 && cx < w && cy < h) {
                 set.add(`${cx}:${cy}`);
@@ -134,6 +137,19 @@ function selectWeapon(mode: 'shot' | 'torpedo' | 'sonar' | 'airraid') {
     weaponMode.value = mode;
 }
 
+// Torpeda ukośna: osobny limit (zwiad — nie trafi jednego statku dwa razy)
+const diagonalAvailable = computed(() => {
+    const d = weapons.value?.torpedoDiagonal;
+    return !!d && d.used < d.limit;
+});
+
+const DIAGONALS = ['NE', 'SE', 'SW', 'NW'];
+watch([diagonalAvailable, torpedoDirection], () => {
+    if (!diagonalAvailable.value && DIAGONALS.includes(torpedoDirection.value)) {
+        torpedoDirection.value = 'E';
+    }
+});
+
 const weaponHint = computed(() => {
     switch (weaponMode.value) {
         case 'torpedo': return 'Kliknij WŁASNY niezatopiony statek (podświetlony na Twojej planszy) — torpeda popłynie z jego pozycji w wybranym kierunku.';
@@ -197,9 +213,14 @@ function newGame() {
             <div v-if="ruleset === 'fun' && weaponMode === 'torpedo'" class="weapon-opts">
                 Kierunek:
                 <label><input type="radio" value="N" v-model="torpedoDirection" /> ↑ N</label>
+                <label><input type="radio" value="NE" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↗ NE</label>
                 <label><input type="radio" value="E" v-model="torpedoDirection" /> → E</label>
+                <label><input type="radio" value="SE" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↘ SE</label>
                 <label><input type="radio" value="S" v-model="torpedoDirection" /> ↓ S</label>
+                <label><input type="radio" value="SW" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↙ SW</label>
                 <label><input type="radio" value="W" v-model="torpedoDirection" /> ← W</label>
+                <label><input type="radio" value="NW" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↖ NW</label>
+                <span v-if="!diagonalAvailable" class="diag-hint">(ukośna zużyta)</span>
             </div>
             <div v-if="weaponHint" class="weapon-hint">{{ weaponHint }}</div>
 
@@ -278,6 +299,8 @@ function newGame() {
 .weapon-opts { margin-top:.35rem; display:flex; gap:.6rem; align-items:center; color:#334155; }
 .weapon-hint { margin-top:.3rem; font-size:.9rem; color:#475569; }
 .ai-arsenal { font-size:.9rem; color:#475569; }
+.diag-hint { font-size:.85rem; color:#94a3b8; }
+.weapon-opts label:has(input:disabled) { opacity:.45; }
 .toast { display:inline-block; padding:.3rem .6rem; border-radius:6px; border:1px solid #cbd5e1; background:#f8fafc; color:#0f172a; }
 .toast.warn { background:#fff7ed; border-color:#fed7aa; color:#7c2d12; }
 .toast.error { background:#fee2e2; border-color:#fecaca; color:#7f1d1d; }

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -138,6 +138,14 @@ export function useGame() {
             status.value = o.win ? 'won' : (o.loss ? 'lost' : status.value);
             finished.value = true;
         }
+        // torpeda AI zdradza wyrzutnię — oznacz jak wykryty sonarem statek
+        if (o.opponentTorpedoLaunch) {
+            const { x, y } = o.opponentTorpedoLaunch;
+            const merged = new Map(sonarMarks.value.map(c => [`${c.x}:${c.y}`, c]));
+            merged.set(`${x}:${y}`, { x, y, occupied: true });
+            sonarMarks.value = [...merged.values()];
+            showToast('📡 Namierzono wyrzutnię torpedy przeciwnika!', 'info', 3000);
+        }
     }
 
     function canAct(): boolean {

--- a/src/Application/Game/FireTorpedo.php
+++ b/src/Application/Game/FireTorpedo.php
@@ -2,6 +2,7 @@
 
 namespace App\Application\Game;
 
+use App\Domain\Game\AI\HuntTargetAI;
 use App\Domain\Game\Coordinate;
 use App\Domain\Game\Direction;
 use App\Domain\Game\GameRepository;
@@ -42,7 +43,14 @@ final class FireTorpedo
 
         $game->setTurn('opponent');
 
-        $results = $game->fireTorpedo(new Coordinate($x, $y), $direction);
+        $launch = new Coordinate($x, $y);
+        $results = $game->fireTorpedo($launch, $direction);
+
+        // Koszt torpedy: zdradza wyrzutnię — AI dostaje pozycję statku gracza
+        // jako cel do dobicia (symetrycznie AI ujawnia swoją w OpponentTurn).
+        $ai = HuntTargetAI::fromSnapshot($game->aiState());
+        $ai->enqueueTargets([$launch]);
+        $game->setAiState($ai->toSnapshot());
 
         $turnOutcome = $this->opponentTurn->respond($game);
 

--- a/src/Application/Game/OpponentTurn.php
+++ b/src/Application/Game/OpponentTurn.php
@@ -34,9 +34,6 @@ final class OpponentTurn
     /** Nalot tylko, gdy obszar 3×3 ma co najmniej tyle nieostrzelanych pól. */
     private const AIR_RAID_MIN_UNTRIED = 6;
 
-    /** Wyrzutnia torpedy AI z ostatniej akcji — do ujawnienia graczowi. */
-    private ?Coordinate $torpedoLaunch = null;
-
     public function __construct(private readonly WeaponUseDecider $decider = new RandomWeaponUseDecider())
     {
     }
@@ -48,11 +45,11 @@ final class OpponentTurn
     {
         $finished = $game->isFinished();
         $opponentMoves = [];
-        $this->torpedoLaunch = null;
+        $torpedoLaunch = null;
 
         if (!$finished) {
             $ai = HuntTargetAI::fromSnapshot($game->aiState());
-            $opponentMoves = $this->act($game, $ai);
+            ['moves' => $opponentMoves, 'torpedoLaunch' => $torpedoLaunch] = $this->act($game, $ai);
             $game->setAiState($ai->toSnapshot());
 
             $finished = $game->isFinished();
@@ -69,13 +66,13 @@ final class OpponentTurn
             'turn' => $turn,
             'opponentMoves' => $opponentMoves,
             // koszt torpedy: zdradza wyrzutnię — gracz widzi, skąd strzelono
-            'opponentTorpedoLaunch' => null !== $this->torpedoLaunch
-                ? ['x' => $this->torpedoLaunch->x, 'y' => $this->torpedoLaunch->y]
+            'opponentTorpedoLaunch' => null !== $torpedoLaunch
+                ? ['x' => $torpedoLaunch->x, 'y' => $torpedoLaunch->y]
                 : null,
         ];
     }
 
-    /** @return list<array{x:int,y:int,result:string}> */
+    /** @return array{moves: list<array{x:int,y:int,result:string}>, torpedoLaunch: Coordinate|null} */
     private function act(Game $game, HuntTargetAI $ai): array
     {
         $view = $game->opponentShotsView();
@@ -105,9 +102,9 @@ final class OpponentTurn
                 [$start, $direction] = $run;
                 $results = $game->fireOpponentTorpedo($start, $direction);
                 $this->notifyAll($ai, $results);
-                $this->torpedoLaunch = $start;
 
-                return $results;
+                // koszt torpedy: wyrzutnia AI zostaje ujawniona graczowi
+                return ['moves' => $results, 'torpedoLaunch' => $start];
             }
         }
 
@@ -117,7 +114,7 @@ final class OpponentTurn
                 $results = $game->sendOpponentAirRaid($center, new Area(1, 1));
                 $this->notifyAll($ai, $results);
 
-                return $results;
+                return ['moves' => $results, 'torpedoLaunch' => null];
             }
         }
 
@@ -125,7 +122,10 @@ final class OpponentTurn
         $result = $game->fireOpponentShot($target);
         $ai->notify($target, $result);
 
-        return [['x' => $target->x, 'y' => $target->y, 'result' => $result->value]];
+        return [
+            'moves' => [['x' => $target->x, 'y' => $target->y, 'result' => $result->value]],
+            'torpedoLaunch' => null,
+        ];
     }
 
     /** @param list<array{x:int,y:int,result:string}> $results */

--- a/src/Application/Game/OpponentTurn.php
+++ b/src/Application/Game/OpponentTurn.php
@@ -34,17 +34,21 @@ final class OpponentTurn
     /** Nalot tylko, gdy obszar 3×3 ma co najmniej tyle nieostrzelanych pól. */
     private const AIR_RAID_MIN_UNTRIED = 6;
 
+    /** Wyrzutnia torpedy AI z ostatniej akcji — do ujawnienia graczowi. */
+    private ?Coordinate $torpedoLaunch = null;
+
     public function __construct(private readonly WeaponUseDecider $decider = new RandomWeaponUseDecider())
     {
     }
 
     /**
-     * @return array{finished:bool, win:bool, loss:bool, turn:string, opponentMoves:list<array{x:int,y:int,result:string}>}
+     * @return array{finished:bool, win:bool, loss:bool, turn:string, opponentMoves:list<array{x:int,y:int,result:string}>, opponentTorpedoLaunch: array{x:int,y:int}|null}
      */
     public function respond(Game $game): array
     {
         $finished = $game->isFinished();
         $opponentMoves = [];
+        $this->torpedoLaunch = null;
 
         if (!$finished) {
             $ai = HuntTargetAI::fromSnapshot($game->aiState());
@@ -64,6 +68,10 @@ final class OpponentTurn
             'loss' => 'lost' === $game->status()->value,
             'turn' => $turn,
             'opponentMoves' => $opponentMoves,
+            // koszt torpedy: zdradza wyrzutnię — gracz widzi, skąd strzelono
+            'opponentTorpedoLaunch' => null !== $this->torpedoLaunch
+                ? ['x' => $this->torpedoLaunch->x, 'y' => $this->torpedoLaunch->y]
+                : null,
         ];
     }
 
@@ -92,11 +100,12 @@ final class OpponentTurn
 
         // 2) Akcja ofensywna: torpeda / nalot (tylko hunt) albo zwykły strzał
         if ($huntMode && $this->hasUses($weapons, 'torpedo') && $this->decide(self::TORPEDO_CHANCE)) {
-            $run = $this->bestTorpedoRun($game, $view);
+            $run = $this->bestTorpedoRun($game, $view, $this->hasUses($weapons, 'torpedoDiagonal'));
             if (null !== $run) {
                 [$start, $direction] = $run;
                 $results = $game->fireOpponentTorpedo($start, $direction);
                 $this->notifyAll($ai, $results);
+                $this->torpedoLaunch = $start;
 
                 return $results;
             }
@@ -163,19 +172,17 @@ final class OpponentTurn
      *
      * @return array{0: Coordinate, 1: Direction}|null
      */
-    private function bestTorpedoRun(Game $game, BoardReadModel $view): ?array
+    private function bestTorpedoRun(Game $game, BoardReadModel $view, bool $diagonalAllowed): ?array
     {
         $best = null;
         $bestScore = self::TORPEDO_MIN_UNTRIED - 1;
 
         foreach ($game->opponentLaunchableCells() as $cell) {
             foreach (Direction::cases() as $direction) {
-                [$dx, $dy] = match ($direction) {
-                    Direction::N => [0, -1],
-                    Direction::S => [0, 1],
-                    Direction::E => [1, 0],
-                    Direction::W => [-1, 0],
-                };
+                if ($direction->isDiagonal() && !$diagonalAllowed) {
+                    continue;
+                }
+                [$dx, $dy] = $direction->vector();
 
                 $score = 0;
                 $cx = $cell['x'];

--- a/src/Domain/Game/ClassicRuleset.php
+++ b/src/Domain/Game/ClassicRuleset.php
@@ -31,6 +31,6 @@ final class ClassicRuleset implements Ruleset
 
     public function weaponLimits(): array
     {
-        return ['torpedo' => 0, 'sonar' => 0, 'airRaid' => 0];
+        return ['torpedo' => 0, 'sonar' => 0, 'airRaid' => 0, 'torpedoDiagonal' => 0];
     }
 }

--- a/src/Domain/Game/Direction.php
+++ b/src/Domain/Game/Direction.php
@@ -5,7 +5,35 @@ namespace App\Domain\Game;
 enum Direction: string
 {
     case N = 'N';
+    case NE = 'NE';
     case E = 'E';
+    case SE = 'SE';
     case S = 'S';
+    case SW = 'SW';
     case W = 'W';
+    case NW = 'NW';
+
+    /** @return array{0:int,1:int} wektor [dx, dy] */
+    public function vector(): array
+    {
+        return match ($this) {
+            self::N => [0, -1],
+            self::NE => [1, -1],
+            self::E => [1, 0],
+            self::SE => [1, 1],
+            self::S => [0, 1],
+            self::SW => [-1, 1],
+            self::W => [-1, 0],
+            self::NW => [-1, -1],
+        };
+    }
+
+    /**
+     * Kierunki ukośne mają osobny limit: statki leżą zawsze w pionie/poziomie,
+     * więc torpeda ukośna nie trafi jednego statku dwa razy — to broń zwiadowcza.
+     */
+    public function isDiagonal(): bool
+    {
+        return in_array($this, [self::NE, self::SE, self::SW, self::NW], true);
+    }
 }

--- a/src/Domain/Game/FunRuleset.php
+++ b/src/Domain/Game/FunRuleset.php
@@ -30,6 +30,7 @@ final class FunRuleset implements Ruleset
 
     public function weaponLimits(): array
     {
-        return ['torpedo' => 2, 'sonar' => 3, 'airRaid' => 1];
+        // torpedoDiagonal = ile z torped może płynąć po przekątnej (podzbiór limitu torpedo)
+        return ['torpedo' => 2, 'sonar' => 3, 'airRaid' => 1, 'torpedoDiagonal' => 1];
     }
 }

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -314,6 +314,31 @@ final class Game
         $this->weaponUses[$shooter][$weapon] = ($this->weaponUses[$shooter][$weapon] ?? 0) + 1;
     }
 
+    /**
+     * Torpeda ukośna ma osobny limit (zwiad — nie trafi jednego statku dwa razy,
+     * za to rozrzuca trafienia po wielu; patrz Direction::isDiagonal()).
+     */
+    private function assertDiagonalTorpedoAvailable(string $shooter, Direction $direction): void
+    {
+        if (!$direction->isDiagonal()) {
+            return;
+        }
+
+        $limit = $this->ruleset->weaponLimits()['torpedoDiagonal'] ?? 0;
+        if (($this->weaponUses[$shooter]['torpedoDiagonal'] ?? 0) >= $limit) {
+            throw new \DomainException('Diagonal torpedo limit reached');
+        }
+    }
+
+    /** Zużycie torpedy: licznik ogólny + osobny dla przekątnych. */
+    private function consumeTorpedo(string $shooter, Direction $direction): void
+    {
+        $this->consumeWeapon($shooter, 'torpedo');
+        if ($direction->isDiagonal()) {
+            $this->weaponUses[$shooter]['torpedoDiagonal'] = ($this->weaponUses[$shooter]['torpedoDiagonal'] ?? 0) + 1;
+        }
+    }
+
     /** Strzały gracza. @return list<array{x:int,y:int}> */
     public function shots(): array
     {
@@ -374,6 +399,7 @@ final class Game
         }
 
         $this->assertWeaponAvailable('player', 'torpedo');
+        $this->assertDiagonalTorpedoAvailable('player', $direction);
 
         $w = $this->ruleset->boardSize()->width;
         $h = $this->ruleset->boardSize()->height;
@@ -386,15 +412,9 @@ final class Game
             throw new \DomainException('Torpedo must be launched from an unsunk ship');
         }
 
-        $this->consumeWeapon('player', 'torpedo');
+        $this->consumeTorpedo('player', $direction);
 
-        // Direction vector
-        [$dx, $dy] = match ($direction) {
-            Direction::N => [0, -1],
-            Direction::S => [0, 1],
-            Direction::E => [1, 0],
-            Direction::W => [-1, 0],
-        };
+        [$dx, $dy] = $direction->vector();
 
         $results = [];
 
@@ -527,6 +547,7 @@ final class Game
         }
 
         $this->assertWeaponAvailable('opponent', 'torpedo');
+        $this->assertDiagonalTorpedoAvailable('opponent', $direction);
 
         $w = $this->ruleset->boardSize()->width;
         $h = $this->ruleset->boardSize()->height;
@@ -539,14 +560,9 @@ final class Game
             throw new \DomainException('Torpedo must be launched from an unsunk ship');
         }
 
-        $this->consumeWeapon('opponent', 'torpedo');
+        $this->consumeTorpedo('opponent', $direction);
 
-        [$dx, $dy] = match ($direction) {
-            Direction::N => [0, -1],
-            Direction::S => [0, 1],
-            Direction::E => [1, 0],
-            Direction::W => [-1, 0],
-        };
+        [$dx, $dy] = $direction->vector();
 
         $results = [];
         $cx = $start->x;

--- a/src/Domain/Game/Ruleset.php
+++ b/src/Domain/Game/Ruleset.php
@@ -21,8 +21,9 @@ interface Ruleset
 
     /**
      * Limity użyć broni specjalnych na grę; 0 = broń niedostępna w tym wariancie.
+     * torpedoDiagonal = ile z torped może płynąć po przekątnej (podzbiór torpedo).
      *
-     * @return array{torpedo:int, sonar:int, airRaid:int}
+     * @return array{torpedo:int, sonar:int, airRaid:int, torpedoDiagonal:int}
      */
     public function weaponLimits(): array;
 }

--- a/src/Infrastructure/Http/Controller/FireTorpedoController.php
+++ b/src/Infrastructure/Http/Controller/FireTorpedoController.php
@@ -34,16 +34,10 @@ final class FireTorpedoController
         $dir = $payload['direction'] ?? null;
 
         if (!is_int($x) || !is_int($y) || !is_string($dir)) {
-            throw new ApiException('Missing or invalid fields: x:int, y:int, direction:string(N|E|S|W)', 'VALIDATION_ERROR', 400);
+            throw new ApiException('Missing or invalid fields: x:int, y:int, direction:string(N|NE|E|SE|S|SW|W|NW)', 'VALIDATION_ERROR', 400);
         }
 
-        $direction = match (strtoupper($dir)) {
-            'N' => Direction::N,
-            'E' => Direction::E,
-            'S' => Direction::S,
-            'W' => Direction::W,
-            default => null,
-        };
+        $direction = Direction::tryFrom(strtoupper($dir));
 
         if (null === $direction) {
             throw new ApiException('Invalid direction', 'VALIDATION_ERROR', 400);

--- a/tests/Unit/Application/OpponentTurnTest.php
+++ b/tests/Unit/Application/OpponentTurnTest.php
@@ -45,6 +45,7 @@ it('AI robi zwykły strzał, gdy losowanie odmawia użycia broni', function () {
         'torpedo' => ['used' => 0, 'limit' => 2],
         'sonar' => ['used' => 0, 'limit' => 3],
         'airRaid' => ['used' => 0, 'limit' => 1],
+        'torpedoDiagonal' => ['used' => 0, 'limit' => 1],
     ]);
 });
 
@@ -75,6 +76,22 @@ it('AI odpala torpedę z niezatopionego statku w linię z nieostrzelanymi polami
     expect(count($out['opponentMoves']))->toBeGreaterThanOrEqual(5);
     // wszystkie strzały torpedy wylądowały na planszy gracza
     expect($game->opponentShots())->toHaveCount(count($out['opponentMoves']));
+    // koszt torpedy: AI zdradza wyrzutnię
+    expect($out['opponentTorpedoLaunch'])->not->toBeNull();
+});
+
+it('reveal wyrzutni: torpeda gracza podpowiada AI, gdzie stoi jego statek', function () {
+    $repo = new App\Infrastructure\Persistence\InMemory\InMemoryGameRepository();
+    $game = funGameWithBothFleets();
+    $game->setTurn('player');
+    $repo->save($game);
+
+    $handler = new App\Application\Game\FireTorpedo($repo, new OpponentTurn(decider(fn (int $pct) => false)));
+    // torpeda gracza z trójmasztowca (0,2) — AI (bez własnych broni) dobija wyrzutnię
+    $out = $handler((string) $game->id(), 0, 2, App\Domain\Game\Direction::E);
+
+    expect($out['opponentMoves'])->toHaveCount(1);
+    expect($out['opponentMoves'][0])->toMatchArray(['x' => 0, 'y' => 2, 'result' => 'hit']);
 });
 
 it('AI używa nalotu, gdy torpeda niedostępna', function () {

--- a/tests/Unit/GameFireTorpedoTest.php
+++ b/tests/Unit/GameFireTorpedoTest.php
@@ -94,6 +94,45 @@ final class GameFireTorpedoTest extends TestCase
         $this->assertCount(10, $results);
     }
 
+    public function testDiagonalTorpedoRunsAlongDiagonal(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+
+        // z 4-masztowca (0,0) po przekątnej SE — komórki (i,i)
+        $results = $game->fireTorpedo(new Coordinate(0, 0), Direction::SE);
+
+        $this->assertCount(10, $results);
+        foreach ($results as $i => $r) {
+            $this->assertSame($i, $r['x']);
+            $this->assertSame($i, $r['y']);
+        }
+        $this->assertSame(1, $game->weaponsState()['torpedoDiagonal']['used']);
+    }
+
+    public function testSecondDiagonalTorpedoIsRejected(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+        $game->fireTorpedo(new Coordinate(0, 0), Direction::SE);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Diagonal torpedo limit reached');
+        $game->fireTorpedo(new Coordinate(0, 2), Direction::NE);
+    }
+
+    public function testStraightTorpedoStillAvailableAfterDiagonal(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+        $game->fireTorpedo(new Coordinate(0, 0), Direction::SE);
+
+        // druga torpeda (prosta) przechodzi — limit ogólny to 2
+        $results = $game->fireTorpedo(new Coordinate(0, 2), Direction::E);
+        $this->assertNotEmpty($results);
+        $this->assertSame(2, $game->weaponsState()['torpedo']['used']);
+    }
+
     public function testFailedLaunchDoesNotConsumeTorpedo(): void
     {
         $game = Game::create(new FunRuleset());

--- a/tests/Unit/GameWeaponLimitsTest.php
+++ b/tests/Unit/GameWeaponLimitsTest.php
@@ -61,6 +61,7 @@ it('raportuje stan broni: użycia i limity', function () {
         'torpedo' => ['used' => 1, 'limit' => 2],
         'sonar' => ['used' => 1, 'limit' => 3],
         'airRaid' => ['used' => 0, 'limit' => 1],
+        'torpedoDiagonal' => ['used' => 0, 'limit' => 1],
     ]);
 });
 


### PR DESCRIPTION
Kontynuacja dyskusji o przekątnych (2026-07-11): kierunki NE/SE/SW/NW dla torped + świadomy balans.

## Mechanika

- **Przekątna = zwiad bojowy**: statki leżą w pionie/poziomie, więc torpeda ukośna nigdy nie trafi jednego statku dwa razy — za to rozrzuca pojedyncze trafienia po wielu (każde = punkt zaczepienia). Prosta pozostaje ciosem egzekucyjnym.
- **Limit: 1 z 2 torped może płynąć po przekątnej** (`torpedoDiagonal` w `weaponLimits`, obie strony symetrycznie).
- **Koszt torpedy: zdradza wyrzutnię** — torpeda gracza dodaje jego pozycję do celów AI (w weryfikacji AI odpowiedziało strzałem DOKŁADNIE w komórkę wyrzutni), torpeda AI zwraca `opponentTorpedoLaunch` i jest oznaczana na planszy wroga jak wykryta sonarem + toast „Namierzono wyrzutnię".

## Techniczne

- `Direction`: 8 wartości + `vector()` / `isDiagonal()` — trzy kopie `match` (Game ×2, OpponentTurn) zastąpione enumem; kontroler parsuje przez `tryFrom`
- nieudana walidacja nie zużywa limitów; AI pomija przekątne bez budżetu
- UI: 8 kierunków, przekątne wyszarzane po zużyciu (wybór wraca na E), podgląd toru działa po skosie

## Weryfikacja

Pest: **93 passed** (tor po (i,i), drugi ukos → 422, prosta po ukośnej OK, reveal w obie strony). PHPStan/cs-fixer/vue-tsc czyste. Przeglądarka: ukośna torpeda zatopiła po drodze 2 jedynki, blokada przekątnych działa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)