### PR TITLE
Fix PHPStan findings from diagonal torpedo PR

### DIFF
--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -324,7 +324,7 @@ final class Game
             return;
         }
 
-        $limit = $this->ruleset->weaponLimits()['torpedoDiagonal'] ?? 0;
+        $limit = $this->ruleset->weaponLimits()['torpedoDiagonal'];
         if (($this->weaponUses[$shooter]['torpedoDiagonal'] ?? 0) >= $limit) {
             throw new \DomainException('Diagonal torpedo limit reached');
         }


### PR DESCRIPTION
Follow-up do #26 — merge poszedł na commicie sprzed poprawki statycznej analizy (static-analysis na main jest czerwone):

- docblock `Ruleset::weaponLimits()` z kluczem `torpedoDiagonal` (offset error)
- `OpponentTurn::act()` zwraca wyrzutnię jawnie zamiast pola-side-channel (PHPStan nie śledzi mutacji pola przez wywołanie metody)
- zbędny null coalesce na gwarantowanym kluczu

PHPStan: **No errors**; Pest: **93 passed** (bez zmian funkcjonalnych).

🤖 Generated with [Claude Code](https://claude.com/claude-code)