### PR TITLE
Torpedo direction as wind rose + fix AI launch reveal on plain shots

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -49,13 +49,8 @@ export interface CreateGameResponse {
     board: { w: number; h: number };
 }
 
-export interface ShotResultDTO {
+export interface ShotResultDTO extends TurnOutcomeDTO {
     result: 'miss' | 'hit' | 'sunk' | 'duplicate';
-    finished: boolean;
-    win: boolean;
-    loss: boolean;
-    turn: 'player' | 'opponent' | 'none';
-    opponentMoves: { x: number; y: number; result: 'hit' | 'miss' | 'sunk' | 'duplicate' }[];
 }
 
 export async function createGame(mode: RulesetName = 'classic', size = 10): Promise<CreateGameResponse> {

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -210,17 +210,20 @@ function newGame() {
                     ✈️ Nalot {{ weapons.airRaid.limit - weapons.airRaid.used }}/{{ weapons.airRaid.limit }}
                 </button>
             </div>
+            <!-- Kierunek torpedy jako róża wiatrów: 3×3, statek w środku -->
             <div v-if="ruleset === 'fun' && weaponMode === 'torpedo'" class="weapon-opts">
-                Kierunek:
-                <label><input type="radio" value="N" v-model="torpedoDirection" /> ↑ N</label>
-                <label><input type="radio" value="NE" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↗ NE</label>
-                <label><input type="radio" value="E" v-model="torpedoDirection" /> → E</label>
-                <label><input type="radio" value="SE" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↘ SE</label>
-                <label><input type="radio" value="S" v-model="torpedoDirection" /> ↓ S</label>
-                <label><input type="radio" value="SW" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↙ SW</label>
-                <label><input type="radio" value="W" v-model="torpedoDirection" /> ← W</label>
-                <label><input type="radio" value="NW" v-model="torpedoDirection" :disabled="!diagonalAvailable" /> ↖ NW</label>
-                <span v-if="!diagonalAvailable" class="diag-hint">(ukośna zużyta)</span>
+                <div class="rose" title="Kierunek torpedy">
+                    <label class="rose-cell"><input type="radio" value="NW" v-model="torpedoDirection" :disabled="!diagonalAvailable" /><span>↖</span></label>
+                    <label class="rose-cell"><input type="radio" value="N" v-model="torpedoDirection" /><span>↑</span></label>
+                    <label class="rose-cell"><input type="radio" value="NE" v-model="torpedoDirection" :disabled="!diagonalAvailable" /><span>↗</span></label>
+                    <label class="rose-cell"><input type="radio" value="W" v-model="torpedoDirection" /><span>←</span></label>
+                    <div class="rose-center" title="Wyrzutnia — Twój statek">🚢</div>
+                    <label class="rose-cell"><input type="radio" value="E" v-model="torpedoDirection" /><span>→</span></label>
+                    <label class="rose-cell"><input type="radio" value="SW" v-model="torpedoDirection" :disabled="!diagonalAvailable" /><span>↙</span></label>
+                    <label class="rose-cell"><input type="radio" value="S" v-model="torpedoDirection" /><span>↓</span></label>
+                    <label class="rose-cell"><input type="radio" value="SE" v-model="torpedoDirection" :disabled="!diagonalAvailable" /><span>↘</span></label>
+                </div>
+                <span v-if="!diagonalAvailable" class="diag-hint">ukośna zużyta</span>
             </div>
             <div v-if="weaponHint" class="weapon-hint">{{ weaponHint }}</div>
 
@@ -297,6 +300,16 @@ function newGame() {
 .wbtn.active { background:#1f6feb; color:#fff; border-color:#1f6feb; }
 .wbtn[disabled] { opacity:.45; cursor:not-allowed; }
 .weapon-opts { margin-top:.35rem; display:flex; gap:.6rem; align-items:center; color:#334155; }
+.rose { display:grid; grid-template-columns: repeat(3, 34px); grid-auto-rows: 34px; gap:4px; }
+.rose-cell {
+    display:flex; align-items:center; justify-content:center;
+    border:1px solid #cbd5e1; border-radius:6px; background:#f8fafc;
+    cursor:pointer; font-size:1.05rem; color:#334155; user-select:none;
+}
+.rose-cell input { display:none; }
+.rose-cell:has(input:checked) { background:#1f6feb; border-color:#1f6feb; color:#fff; }
+.rose-cell:has(input:disabled) { opacity:.35; cursor:not-allowed; }
+.rose-center { display:flex; align-items:center; justify-content:center; font-size:1.2rem; }
 .weapon-hint { margin-top:.3rem; font-size:.9rem; color:#475569; }
 .ai-arsenal { font-size:.9rem; color:#475569; }
 .diag-hint { font-size:.85rem; color:#94a3b8; }

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -9,6 +9,7 @@ import { useRouter } from 'vue-router'
 const {
     status, finished, turn, loading, error, disabled, attack, width, height,
     ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
+    noteMarks, toggleNote,
     shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
     toast, toastType,
     playerGrid, playerUnderFireOverlay, enemyFogGrid, lastShot, sunkCells,
@@ -104,6 +105,11 @@ const enemyAnimatedGrid = computed<string[][]>(() => {
             classes += sonar.get(`${x}:${y}`) ? ' sonar-ship' : ' sonar-water';
         }
 
+        // Notatka gracza „tu pusto" (tylko nieostrzelane pola)
+        if (cell === 'empty' && noteMarks.value.has(`${x}:${y}`)) {
+            classes += ' note';
+        }
+
         // Podgląd zasięgu broni pod kursorem
         if (previewCells.value.has(`${x}:${y}`)) {
             classes += ' preview';
@@ -187,7 +193,8 @@ function newGame() {
             <GameGameBoard :grid="enemyAnimatedGrid" :disabled="disabled"
                            :onCellClick="weaponMode === 'torpedo' ? undefined : handleShot"
                            :onCellHover="weaponMode === 'torpedo' ? undefined : handleHover"
-                           :onBoardLeave="handleBoardLeave" />
+                           :onBoardLeave="handleBoardLeave"
+                           :onCellRightClick="toggleNote" />
 
             <!-- Panel broni specjalnych (tylko tryb fun) -->
             <div v-if="ruleset === 'fun' && weapons" class="weapons">
@@ -251,6 +258,7 @@ function newGame() {
                     <span class="item"><span class="box miss"></span> Pudło</span>
                     <span class="item"><span class="box opp-hit"></span> Trafienie przeciwnika</span>
                     <span class="item"><span class="box opp-miss"></span> Pudło przeciwnika</span>
+                    <span class="item"><span class="box note"></span> Notatka „pusto" (PPM)</span>
                     <template v-if="ruleset === 'fun'">
                         <span class="item"><span class="box sonar-ship"></span> Sonar: statek</span>
                         <span class="item"><span class="box sonar-water"></span> Sonar: woda</span>
@@ -295,6 +303,7 @@ function newGame() {
 .legend .box.opp-miss { background: transparent; border-color:#0c4a6e; box-shadow: inset 0 0 0 2px #0c4a6e; }
 .legend .box.sonar-ship { background: #fef3c7; border-color:#d97706; box-shadow: inset 0 0 0 2px #d97706; }
 .legend .box.sonar-water { background: #f0f9ff; border-color:#7dd3fc; }
+.legend .box.note { background-image: repeating-linear-gradient(45deg, rgba(100,116,139,.45) 0 2px, transparent 2px 5px); }
 .weapons { display:flex; gap:.4rem; margin-top:.6rem; flex-wrap:wrap; }
 .wbtn { padding:.3rem .6rem; border:1px solid #cbd5e1; border-radius:6px; background:#f8fafc; cursor:pointer; }
 .wbtn.active { background:#1f6feb; color:#fff; border-color:#1f6feb; }

--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
     onCellClick?: (x: number, y: number) => void;
     onCellHover?: (x: number, y: number) => void;
     onBoardLeave?: () => void;
+    onCellRightClick?: (x: number, y: number) => void;
 }>();
 
 // Przyjmujemy dowolne klasy komórek (np. 'ship', 'hit', 'miss', 'opp-hit', 'opp-miss')
@@ -47,6 +48,7 @@ function handleClick(x: number, y: number) {
                 :title="typeof cell === 'string' && (cell.includes('opp-hit') || cell.includes('opp-miss')) ? (cell.includes('opp-hit') ? 'Trafienie przeciwnika' : 'Pudło przeciwnika') : ''"
                 @click="handleClick(x, y)"
                 @mouseenter="props.onCellHover?.(x, y)"
+                @contextmenu.prevent="props.onCellRightClick?.(x, y)"
             />
         </div>
     </div>
@@ -197,6 +199,15 @@ function handleClick(x: number, y: number) {
 .cell.launch {
     box-shadow: inset 0 0 0 3px #16a34a;
     cursor: pointer;
+}
+
+/* Notatka gracza a'la saper: „tu nic nie może być" (PPM) */
+.cell.note {
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(100, 116, 139, 0.45) 0 2px,
+        transparent 2px 7px
+    );
 }
 
 </style>

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -44,6 +44,22 @@ export function useGame() {
     const sonarMarks = ref<SonarCell[]>([]);
     // Flota gracza (do wyznaczania wyrzutni torped)
     const playerFleet = ref<PlayerFleetItem[]>([]);
+    // Notatki gracza a'la saper: „tu nic nie może być" — szkic po stronie klienta,
+    // nie kosztuje tury, klucze "x:y"
+    const noteMarks = ref<Set<string>>(new Set());
+
+    function toggleNote(x: number, y: number) {
+        // notatka ma sens tylko na nieostrzelanym polu
+        if (enemyFogGrid.value[y]?.[x] !== 'empty') return;
+        const key = `${x}:${y}`;
+        const next = new Set(noteMarks.value);
+        if (next.has(key)) {
+            next.delete(key);
+        } else {
+            next.add(key);
+        }
+        noteMarks.value = next;
+    }
 
 
     function buildEmptyGrid<T extends string>(w: number, h: number, fill: T): T[][] {
@@ -336,6 +352,8 @@ export function useGame() {
         loading, error, start, refresh, shot, attack, disabled,
         // tryb fun
         ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
+        // notatki (saper-style)
+        noteMarks, toggleNote,
         // stats
         shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
         // toast

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -213,12 +213,9 @@ export function useGame() {
                 duplicates.value += 1;
                 showToast('Duplikat: to pole było już ostrzelane.', 'warn', 2200);
             }
-            // Ruch przeciwnika można wizualizować na osobnej planszy (na MVP pomijamy)
-            turn.value = res.turn;
-            if (res.finished) {
-                status.value = res.win ? 'won' : (res.loss ? 'lost' : status.value);
-                finished.value = true;
-            }
+            // Tura/koniec gry + ewentualne ujawnienie wyrzutni torpedy AI
+            // (AI może odpalić torpedę także w odpowiedzi na zwykły strzał!)
+            applyTurnOutcome(res);
             // Refetch pełnej projekcji, by zsynchronizować mgłę i stany
             await refresh();
         } catch (e: any) {

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -324,7 +324,7 @@ final class Game
             return;
         }
 
-        $limit = $this->ruleset->weaponLimits()['torpedoDiagonal'] ?? 0;
+        $limit = $this->ruleset->weaponLimits()['torpedoDiagonal'];
         if (($this->weaponUses[$shooter]['torpedoDiagonal'] ?? 0) >= $limit) {
             throw new \DomainException('Diagonal torpedo limit reached');
         }


### PR DESCRIPTION
Feedback z rozgrywki (2026-07-11):

## Róża wiatrów

Kierunek torpedy jako siatka **3×3 ze statkiem 🚢 w środku** — zamiast rzędu radiosów. Przekątne wyszarzane po zużyciu limitu jak dotąd, wybór wraca na →.

## Fix: „nie widzę skąd strzela AI"

Ujawnienie wyrzutni torpedy AI działało **tylko wtedy, gdy Twój ruch był torpedą lub nalotem** — zwykły strzał (`shot()`) ręcznie obsługiwał turę i ignorował `opponentTorpedoLaunch` z odpowiedzi, a AI najczęściej odpala torpedę właśnie w odpowiedzi na zwykły strzał. Po poprawce każda ścieżka przechodzi przez `applyTurnOutcome`: żółte oznaczenie wyrzutni na planszy wroga + toast „Namierzono wyrzutnię". `ShotResultDTO` dziedziczy teraz z `TurnOutcomeDTO` (koniec dublowania pól).

Sama linia ostrzału zaczyna się od pozycji wyrzutni (tak jak u gracza) — z widocznym oznaczeniem startu przestaje wyglądać jak „strzał przez całą linię".

Zawiera też cherry-pick poprawki PHPStan z #27 (żeby CI tego PR-a było zielone niezależnie od kolejności merge; po merge #27 commit staje się no-op).

## Weryfikacja

vue-tsc/vite build OK; przeglądarka: róża renderuje się i przełącza (E→SE), statek w środku, przekątne aktywne. Pest: **93 passed**, PHPStan: No errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)