### PR TITLE
Introduce WeaponSpec: ruleset-defined weapon shape, range and uses

### DIFF
--- a/src/Application/Game/OpponentTurn.php
+++ b/src/Application/Game/OpponentTurn.php
@@ -18,7 +18,7 @@ use App\Domain\Game\ShotResult;
  *   (jak u gracza nie zużywa akcji ofensywnej),
  * - torpeda: z pozycji własnego niezatopionego statku, w linię z największą
  *   liczbą nieostrzelanych pól,
- * - nalot: w najgęstszy nieostrzelany obszar 3×3.
+ * - nalot: w najgęstszy nieostrzelany obszar (rozmiar maksymalny z rulesetu).
  * Bronie tylko w trybie hunt (przy dobijaniu zwykły strzał jest skuteczniejszy),
  * z losową częstością — AI nie może być przewidywalne.
  */
@@ -31,7 +31,7 @@ final class OpponentTurn
     /** Torpeda tylko, gdy linia ma co najmniej tyle nieostrzelanych pól. */
     private const TORPEDO_MIN_UNTRIED = 5;
 
-    /** Nalot tylko, gdy obszar 3×3 ma co najmniej tyle nieostrzelanych pól. */
+    /** Nalot tylko, gdy obszar nalotu ma co najmniej tyle nieostrzelanych pól. */
     private const AIR_RAID_MIN_UNTRIED = 6;
 
     public function __construct(private readonly WeaponUseDecider $decider = new RandomWeaponUseDecider())
@@ -81,7 +81,7 @@ final class OpponentTurn
 
         // 1) Zwiad: sonar w trybie hunt (nie zużywa akcji ofensywnej)
         if ($huntMode && $this->hasUses($weapons, 'sonar') && $this->decide(self::SONAR_CHANCE)) {
-            $center = $this->bestSonarCenter($view);
+            $center = $this->bestSonarCenter($view, $game->ruleset()->weapons()->sonar->radius);
             if (null !== $center) {
                 $detected = [];
                 foreach ($game->opponentSonarPing($center) as $cell) {
@@ -109,9 +109,10 @@ final class OpponentTurn
         }
 
         if ($huntMode && $this->hasUses($weapons, 'airRaid') && $this->decide(self::AIR_RAID_CHANCE)) {
-            $center = $this->bestAirRaidCenter($view);
+            [$halfX, $halfY] = $this->airRaidHalfExtents($game);
+            $center = $this->bestAirRaidCenter($view, $halfX, $halfY);
             if (null !== $center) {
-                $results = $game->sendOpponentAirRaid($center, new Area(1, 1));
+                $results = $game->sendOpponentAirRaid($center, new Area($halfX, $halfY));
                 $this->notifyAll($ai, $results);
 
                 return ['moves' => $results, 'torpedoLaunch' => null];
@@ -148,14 +149,14 @@ final class OpponentTurn
     }
 
     /** Środek krzyża sonaru maksymalizujący nieostrzelane pola. */
-    private function bestSonarCenter(BoardReadModel $view): ?Coordinate
+    private function bestSonarCenter(BoardReadModel $view, int $radius): ?Coordinate
     {
         $best = null;
         $bestScore = 0;
 
         for ($y = 0; $y < $view->height(); ++$y) {
             for ($x = 0; $x < $view->width(); ++$x) {
-                $score = $this->countUntried($view, $this->sonarCross($view, $x, $y));
+                $score = $this->countUntried($view, $this->sonarCross($x, $y, $radius));
                 if ($score > $bestScore) {
                     $bestScore = $score;
                     $best = new Coordinate($x, $y);
@@ -205,8 +206,8 @@ final class OpponentTurn
         return $best;
     }
 
-    /** Centrum nalotu 3×3 maksymalizujące nieostrzelane pola; null poniżej progu. */
-    private function bestAirRaidCenter(BoardReadModel $view): ?Coordinate
+    /** Centrum nalotu maksymalizujące nieostrzelane pola; null poniżej progu. */
+    private function bestAirRaidCenter(BoardReadModel $view, int $halfX, int $halfY): ?Coordinate
     {
         $best = null;
         $bestScore = self::AIR_RAID_MIN_UNTRIED - 1;
@@ -214,8 +215,8 @@ final class OpponentTurn
         for ($y = 0; $y < $view->height(); ++$y) {
             for ($x = 0; $x < $view->width(); ++$x) {
                 $cells = [];
-                for ($dx = -1; $dx <= 1; ++$dx) {
-                    for ($dy = -1; $dy <= 1; ++$dy) {
+                for ($dx = -$halfX; $dx <= $halfX; ++$dx) {
+                    for ($dy = -$halfY; $dy <= $halfY; ++$dy) {
                         $cells[] = [$x + $dx, $y + $dy];
                     }
                 }
@@ -230,11 +231,23 @@ final class OpponentTurn
         return $best;
     }
 
-    /** @return list<array{0:int,1:int}> komórki krzyża sonaru (promień 3) */
-    private function sonarCross(BoardReadModel $view, int $x, int $y): array
+    /**
+     * Pół-zasięgi maksymalnego nalotu z rulesetu (pełny rozmiar → half-extents).
+     *
+     * @return array{0:int, 1:int}
+     */
+    private function airRaidHalfExtents(Game $game): array
+    {
+        $max = $game->ruleset()->weapons()->airRaid->maxArea;
+
+        return [intdiv(max(0, $max->width - 1), 2), intdiv(max(0, $max->height - 1), 2)];
+    }
+
+    /** @return list<array{0:int,1:int}> komórki krzyża sonaru o zadanym promieniu */
+    private function sonarCross(int $x, int $y, int $radius): array
     {
         $cells = [[$x, $y]];
-        for ($i = 1; $i <= 3; ++$i) {
+        for ($i = 1; $i <= $radius; ++$i) {
             $cells[] = [$x, $y - $i];
             $cells[] = [$x + $i, $y];
             $cells[] = [$x, $y + $i];

--- a/src/Application/Game/SonarPing.php
+++ b/src/Application/Game/SonarPing.php
@@ -14,22 +14,24 @@ final class SonarPing
 
     /**
      * Executes a sonar ping and returns occupancy info for scanned cells.
+     * Radius null = maksymalny promień z rulesetu gry.
      *
-     * @return list<array{x:int,y:int,occupied:bool}>
+     * @return array{radius:int, cells:list<array{x:int,y:int,occupied:bool}>}
      */
-    public function __invoke(string $gameId, int $x, int $y, int $radius = 3): array
+    public function __invoke(string $gameId, int $x, int $y, ?int $radius = null): array
     {
         $game = $this->repo->get(new GameId($gameId));
         if (null === $game) {
             throw new \DomainException('Game not found');
         }
 
+        $effectiveRadius = $radius ?? $game->ruleset()->weapons()->sonar->radius;
         $results = $game->sonarPing(new Coordinate($x, $y), $radius);
 
         // Sonar is informational; no state changes to persist aside from potential future logging.
         // Still, save ensures consistency if in the future sonar updates visibility state.
         $this->repo->save($game);
 
-        return $results;
+        return ['radius' => $effectiveRadius, 'cells' => $results];
     }
 }

--- a/src/Domain/Game/Area.php
+++ b/src/Domain/Game/Area.php
@@ -4,7 +4,7 @@ namespace App\Domain\Game;
 
 /**
  * Rozmiar prostokątnego obszaru. W żądaniu nalotu width/height to pół-zasięgi
- * od punktu centralnego (0 = pojedynczy wiersz/kolumna); w Ruleset::airRaidSize()
+ * od punktu centralnego (0 = pojedynczy wiersz/kolumna); w AirRaidSpec::maxArea
  * — maksymalny pełny rozmiar obszaru w komórkach.
  */
 final class Area

--- a/src/Domain/Game/ClassicRuleset.php
+++ b/src/Domain/Game/ClassicRuleset.php
@@ -2,6 +2,8 @@
 
 namespace App\Domain\Game;
 
+use App\Domain\Game\Weapon\WeaponSpecs;
+
 final class ClassicRuleset implements Ruleset
 {
     public function __construct(private BoardSize $size = new BoardSize(10, 10))
@@ -24,13 +26,8 @@ final class ClassicRuleset implements Ruleset
         return [4 => 1, 3 => 2, 2 => 3, 1 => 4];
     }
 
-    public function airRaidSize(): Area
+    public function weapons(): WeaponSpecs
     {
-        throw new \DomainException('Not accepted in classic ruleset');
-    }
-
-    public function weaponLimits(): array
-    {
-        return ['torpedo' => 0, 'sonar' => 0, 'airRaid' => 0, 'torpedoDiagonal' => 0];
+        return WeaponSpecs::none();
     }
 }

--- a/src/Domain/Game/FunRuleset.php
+++ b/src/Domain/Game/FunRuleset.php
@@ -2,6 +2,11 @@
 
 namespace App\Domain\Game;
 
+use App\Domain\Game\Weapon\AirRaidSpec;
+use App\Domain\Game\Weapon\SonarSpec;
+use App\Domain\Game\Weapon\TorpedoSpec;
+use App\Domain\Game\Weapon\WeaponSpecs;
+
 final class FunRuleset implements Ruleset
 {
     public function __construct(private BoardSize $size = new BoardSize(10, 10))
@@ -23,14 +28,12 @@ final class FunRuleset implements Ruleset
         return [4 => 1, 3 => 2, 2 => 3, 1 => 4];
     }
 
-    public function airRaidSize(): Area
+    public function weapons(): WeaponSpecs
     {
-        return new Area(3, 3);
-    }
-
-    public function weaponLimits(): array
-    {
-        // torpedoDiagonal = ile z torped może płynąć po przekątnej (podzbiór limitu torpedo)
-        return ['torpedo' => 2, 'sonar' => 3, 'airRaid' => 1, 'torpedoDiagonal' => 1];
+        return new WeaponSpecs(
+            torpedo: new TorpedoSpec(uses: 2, diagonalUses: 1),
+            sonar: new SonarSpec(uses: 3, radius: 3),
+            airRaid: new AirRaidSpec(uses: 1, maxArea: new Area(3, 3)),
+        );
     }
 }

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -29,8 +29,8 @@ final class Game
 
     /**
      * Liczba użyć broni specjalnych per strona (klucze zewn.: player|opponent,
-     * wewn.: torpedo|sonar|airRaid). Limity per grę i stronę definiuje
-     * Ruleset::weaponLimits(); 0 = broń niedostępna.
+     * wewn.: torpedo|sonar|airRaid). Limity per grę i stronę definiują
+     * specyfikacje broni z Ruleset::weapons(); 0 = broń niedostępna.
      *
      * @var array{player: array<string,int>, opponent: array<string,int>}
      */
@@ -262,7 +262,7 @@ final class Game
     private function weaponsStateFor(string $shooter): array
     {
         $out = [];
-        foreach ($this->ruleset->weaponLimits() as $weapon => $limit) {
+        foreach ($this->ruleset->weapons()->limits() as $weapon => $limit) {
             $out[$weapon] = ['used' => $this->weaponUses[$shooter][$weapon] ?? 0, 'limit' => $limit];
         }
 
@@ -298,7 +298,7 @@ final class Game
     /** Rzuca, gdy broń niedostępna w rulesecie albo limit danej strony wyczerpany. */
     private function assertWeaponAvailable(string $shooter, string $weapon): void
     {
-        $limit = $this->ruleset->weaponLimits()[$weapon] ?? 0;
+        $limit = $this->ruleset->weapons()->limits()[$weapon] ?? 0;
         if ($limit <= 0) {
             throw new \DomainException(sprintf('%s not available in this ruleset', ucfirst($weapon)));
         }
@@ -324,7 +324,7 @@ final class Game
             return;
         }
 
-        $limit = $this->ruleset->weaponLimits()['torpedoDiagonal'];
+        $limit = $this->ruleset->weapons()->torpedo->diagonalUses;
         if (($this->weaponUses[$shooter]['torpedoDiagonal'] ?? 0) >= $limit) {
             throw new \DomainException('Diagonal torpedo limit reached');
         }
@@ -337,6 +337,23 @@ final class Game
         if ($direction->isDiagonal()) {
             $this->weaponUses[$shooter]['torpedoDiagonal'] = ($this->weaponUses[$shooter]['torpedoDiagonal'] ?? 0) + 1;
         }
+    }
+
+    /**
+     * Efektywny promień sonaru: null = maksymalny ze specu; ponad spec — błąd.
+     * Najpierw dostępność broni, żeby classic zgłaszał 'not available', nie zasięg.
+     */
+    private function resolveSonarRadius(string $shooter, ?int $radius): int
+    {
+        $this->assertWeaponAvailable($shooter, 'sonar');
+
+        $spec = $this->ruleset->weapons()->sonar;
+        $radius ??= $spec->radius;
+        if ($radius > $spec->radius) {
+            throw new \DomainException('Sonar radius exceeds ruleset limit');
+        }
+
+        return $radius;
     }
 
     /** Strzały gracza. @return list<array{x:int,y:int}> */
@@ -435,15 +452,17 @@ final class Game
      * Sonar ping: reveals occupancy info for the center and up to $radius cells
      * in each cardinal direction (cross shape). It does not modify shots/hits.
      * Skanuje stronę, w którą strzela gracz (przeciwnika; fallback jak fireShot).
+     * Promień null = maksymalny z rulesetu; większy niż spec — błąd domenowy.
      *
      * @return list<array{x:int,y:int,occupied:bool}>
      */
-    public function sonarPing(Coordinate $center, int $radius = 3): array
+    public function sonarPing(Coordinate $center, ?int $radius = null): array
     {
         if (!$this->playerSide->hasFleet()) {
             throw new \DomainException('Fleet not placed');
         }
 
+        $radius = $this->resolveSonarRadius('player', $radius);
         $this->consumeWeapon('player', 'sonar');
 
         $target = $this->targetSide();
@@ -498,7 +517,9 @@ final class Game
             throw new \DomainException('Air Raid start outside board');
         }
 
-        $max = $this->ruleset->airRaidSize();
+        $this->assertWeaponAvailable('player', 'airRaid');
+
+        $max = $this->ruleset->weapons()->airRaid->maxArea;
         if (2 * $area->width + 1 > $max->width || 2 * $area->height + 1 > $max->height) {
             throw new \DomainException('Air Raid area is oversize');
         }
@@ -578,16 +599,18 @@ final class Game
     }
 
     /**
-     * Sonar AI: skanuje planszę gracza (krzyż o promieniu $radius). Bez zmian stanu strzałów.
+     * Sonar AI: skanuje planszę gracza (krzyż; promień jak u gracza — z rulesetu).
+     * Bez zmian stanu strzałów.
      *
      * @return list<array{x:int,y:int,occupied:bool}>
      */
-    public function opponentSonarPing(Coordinate $center, int $radius = 3): array
+    public function opponentSonarPing(Coordinate $center, ?int $radius = null): array
     {
         if (!$this->playerSide->hasFleet()) {
             throw new \DomainException('Fleet not placed');
         }
 
+        $radius = $this->resolveSonarRadius('opponent', $radius);
         $this->consumeWeapon('opponent', 'sonar');
 
         $w = $this->ruleset->boardSize()->width;
@@ -633,7 +656,9 @@ final class Game
             throw new \DomainException('Air Raid start outside board');
         }
 
-        $max = $this->ruleset->airRaidSize();
+        $this->assertWeaponAvailable('opponent', 'airRaid');
+
+        $max = $this->ruleset->weapons()->airRaid->maxArea;
         if (2 * $area->width + 1 > $max->width || 2 * $area->height + 1 > $max->height) {
             throw new \DomainException('Air Raid area is oversize');
         }

--- a/src/Domain/Game/Ruleset.php
+++ b/src/Domain/Game/Ruleset.php
@@ -2,6 +2,8 @@
 
 namespace App\Domain\Game;
 
+use App\Domain\Game\Weapon\WeaponSpecs;
+
 interface Ruleset
 {
     /** Identyfikator wariantu zasad: 'classic' | 'fun' (do snapshotu i API). */
@@ -15,15 +17,8 @@ interface Ruleset
     public function allowedShips(): array;
 
     /**
-     * Maksymalny pełny rozmiar obszaru nalotu (w komórkach).
+     * Parametry broni specjalnych wariantu (kształt, zasięg, limity użyć);
+     * uses = 0 oznacza broń niedostępną.
      */
-    public function airRaidSize(): Area;
-
-    /**
-     * Limity użyć broni specjalnych na grę; 0 = broń niedostępna w tym wariancie.
-     * torpedoDiagonal = ile z torped może płynąć po przekątnej (podzbiór torpedo).
-     *
-     * @return array{torpedo:int, sonar:int, airRaid:int, torpedoDiagonal:int}
-     */
-    public function weaponLimits(): array;
+    public function weapons(): WeaponSpecs;
 }

--- a/src/Domain/Game/Weapon/AirRaidSpec.php
+++ b/src/Domain/Game/Weapon/AirRaidSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Domain\Game\Weapon;
+
+use App\Domain\Game\Area;
+
+/**
+ * Parametry nalotu: liczba użyć na grę i stronę oraz maksymalny pełny rozmiar
+ * ostrzeliwanego obszaru w komórkach (żądanie nalotu posługuje się pół-zasięgami).
+ */
+final class AirRaidSpec
+{
+    public function __construct(
+        public readonly int $uses,
+        public readonly Area $maxArea,
+    ) {
+        if ($uses < 0) {
+            throw new \InvalidArgumentException('Negative air raid uses');
+        }
+    }
+}

--- a/src/Domain/Game/Weapon/SonarSpec.php
+++ b/src/Domain/Game/Weapon/SonarSpec.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Domain\Game\Weapon;
+
+/**
+ * Parametry sonaru: liczba użyć na grę i stronę oraz maksymalny promień
+ * krzyża skanowania (0 = tylko komórka centralna).
+ */
+final class SonarSpec
+{
+    public function __construct(
+        public readonly int $uses,
+        public readonly int $radius = 0,
+    ) {
+        if ($uses < 0 || $radius < 0) {
+            throw new \InvalidArgumentException('Negative sonar spec value');
+        }
+    }
+}

--- a/src/Domain/Game/Weapon/TorpedoSpec.php
+++ b/src/Domain/Game/Weapon/TorpedoSpec.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Domain\Game\Weapon;
+
+/**
+ * Parametry torpedy: liczba użyć na grę i stronę oraz ile z nich może płynąć
+ * po przekątnej (podzbiór puli użyć; patrz Direction::isDiagonal()).
+ */
+final class TorpedoSpec
+{
+    public function __construct(
+        public readonly int $uses,
+        public readonly int $diagonalUses = 0,
+    ) {
+        if ($uses < 0 || $diagonalUses < 0) {
+            throw new \InvalidArgumentException('Negative torpedo uses');
+        }
+        if ($diagonalUses > $uses) {
+            throw new \InvalidArgumentException('Diagonal uses exceed torpedo uses');
+        }
+    }
+}

--- a/src/Domain/Game/Weapon/WeaponSpecs.php
+++ b/src/Domain/Game/Weapon/WeaponSpecs.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Domain\Game\Weapon;
+
+use App\Domain\Game\Area;
+
+/**
+ * Komplet parametrów broni specjalnych wariantu zasad (kształt, zasięg, użycia).
+ * uses = 0 oznacza broń niedostępną w danym wariancie.
+ */
+final class WeaponSpecs
+{
+    public function __construct(
+        public readonly TorpedoSpec $torpedo,
+        public readonly SonarSpec $sonar,
+        public readonly AirRaidSpec $airRaid,
+    ) {
+    }
+
+    /** Wariant bez broni specjalnych (classic). */
+    public static function none(): self
+    {
+        return new self(
+            torpedo: new TorpedoSpec(uses: 0),
+            sonar: new SonarSpec(uses: 0),
+            airRaid: new AirRaidSpec(uses: 0, maxArea: new Area(0, 0)),
+        );
+    }
+
+    /**
+     * Limity użyć w płaskim kształcie stanu broni — klucze są stabilne
+     * (snapshot, API i frontend na nich polegają).
+     *
+     * @return array{torpedo:int, sonar:int, airRaid:int, torpedoDiagonal:int}
+     */
+    public function limits(): array
+    {
+        return [
+            'torpedo' => $this->torpedo->uses,
+            'sonar' => $this->sonar->uses,
+            'airRaid' => $this->airRaid->uses,
+            'torpedoDiagonal' => $this->torpedo->diagonalUses,
+        ];
+    }
+}

--- a/src/Infrastructure/Http/Controller/SonarController.php
+++ b/src/Infrastructure/Http/Controller/SonarController.php
@@ -30,19 +30,20 @@ final class SonarController
 
         $x = $payload['x'] ?? null;
         $y = $payload['y'] ?? null;
-        $radius = $payload['radius'] ?? 3;
+        // radius opcjonalny — brak oznacza maksymalny promień z rulesetu
+        $radius = $payload['radius'] ?? null;
 
-        if (!is_int($x) || !is_int($y) || !is_int($radius) || $radius < 0) {
+        if (!is_int($x) || !is_int($y) || (null !== $radius && (!is_int($radius) || $radius < 0))) {
             throw new ApiException('Missing or invalid fields: x:int, y:int, radius:int>=0', 'VALIDATION_ERROR', 400);
         }
 
         // DomainException zostanie obsłużony przez ExceptionSubscriber
-        $list = ($this->sonarPing)($id, $x, $y, $radius);
+        $out = ($this->sonarPing)($id, $x, $y, $radius);
 
         return new JsonResponse([
-            'results' => $list, // list of {x,y,occupied}
+            'results' => $out['cells'], // list of {x,y,occupied}
             'shape' => 'cross',
-            'radius' => $radius,
+            'radius' => $out['radius'],
         ]);
     }
 }

--- a/tests/Unit/WeaponSpecsTest.php
+++ b/tests/Unit/WeaponSpecsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Game\BoardSize;
+use App\Domain\Game\ClassicRuleset;
+use App\Domain\Game\Coordinate;
+use App\Domain\Game\FunRuleset;
+use App\Domain\Game\Game;
+use App\Domain\Game\Weapon\TorpedoSpec;
+use Tests\Support\FleetFactory;
+
+function funGameForSpecs(): Game
+{
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10)));
+    $game->placeFleet(FleetFactory::classic10x10());
+
+    return $game;
+}
+
+it('fun ruleset ma pełne specyfikacje broni', function () {
+    $weapons = (new FunRuleset())->weapons();
+
+    expect($weapons->torpedo->uses)->toBe(2)
+        ->and($weapons->torpedo->diagonalUses)->toBe(1)
+        ->and($weapons->sonar->uses)->toBe(3)
+        ->and($weapons->sonar->radius)->toBe(3)
+        ->and($weapons->airRaid->uses)->toBe(1)
+        ->and($weapons->airRaid->maxArea->width)->toBe(3)
+        ->and($weapons->airRaid->maxArea->height)->toBe(3);
+});
+
+it('classic ruleset nie ma broni specjalnych', function () {
+    expect((new ClassicRuleset())->weapons()->limits())->toBe([
+        'torpedo' => 0,
+        'sonar' => 0,
+        'airRaid' => 0,
+        'torpedoDiagonal' => 0,
+    ]);
+});
+
+it('odrzuca spec torpedy z pulą przekątnych większą niż pula użyć', function () {
+    new TorpedoSpec(uses: 1, diagonalUses: 2);
+})->throws(InvalidArgumentException::class, 'Diagonal uses exceed torpedo uses');
+
+it('odrzuca sonar o promieniu ponad spec z rulesetu', function () {
+    funGameForSpecs()->sonarPing(new Coordinate(5, 5), 4);
+})->throws(DomainException::class, 'Sonar radius exceeds ruleset limit');
+
+it('sonar o promieniu ponad spec nie zużywa użycia', function () {
+    $game = funGameForSpecs();
+
+    try {
+        $game->sonarPing(new Coordinate(5, 5), 4);
+    } catch (DomainException) {
+        // ponad limit z rulesetu — oczekiwane
+    }
+
+    expect($game->weaponsState()['sonar']['used'])->toBe(0);
+});
+
+it('sonar bez podanego promienia skanuje pełnym promieniem z rulesetu', function () {
+    // środek planszy: pełny krzyż r=3 → 1 + 4×3 = 13 komórek
+    expect(funGameForSpecs()->sonarPing(new Coordinate(5, 5)))->toHaveCount(13);
+});
+
+it('sonar z mniejszym promieniem skanuje mniejszy krzyż', function () {
+    expect(funGameForSpecs()->sonarPing(new Coordinate(5, 5), 1))->toHaveCount(5);
+});


### PR DESCRIPTION
Closes #30

## Co

Parametry broni specjalnych przechodzą z hardcodu do specyfikacji w rulesecie — krok 0 wizji z `docs/GAME_DESIGN.md` (fundament pod technologie z rosnącymi zasięgami i „broń ze składu floty").

- Nowe VO w `src/Domain/Game/Weapon/`: `TorpedoSpec` (uses, diagonalUses ≤ uses), `SonarSpec` (uses, radius), `AirRaidSpec` (uses, maxArea), `WeaponSpecs` (agregat + `limits()` w dotychczasowym kształcie kluczy + `none()`)
- `Ruleset::weapons()` zastępuje `weaponLimits()` i `airRaidSize()`; Classic = `WeaponSpecs::none()`, Fun = dotychczasowe wartości (torpeda 2/1 ukośna, sonar 3×r3, nalot 1×3×3)
- `Game`: limity, promień sonaru i maks. obszar nalotu ze speców; kształt `weaponsState()` i snapshot bez zmian
- AI (`OpponentTurn`): promień sonaru i pół-zasięgi nalotu z rulesetu zamiast hardcodu

## Świadome zmiany zachowania

1. **Promień sonaru waliduje ruleset** — dotąd endpoint przyjmował dowolny `radius` od klienta (dało się zeskanować pół planszy jednym użyciem). Teraz: brak parametru = maksimum ze specu, ponad spec = błąd domenowy (nie zużywa użycia). Frontend nie wysyła `radius` — bez wpływu.
2. Nalot w classic zgłasza `AirRaid not available in this ruleset` (spójnie z torpedą/sonarem) zamiast dawnego `Not accepted in classic ruleset`.
3. Odpowiedź sonaru echem zwraca **efektywny** promień (frontend czyta tylko `results`).

## Testy

- Nowy `tests/Unit/WeaponSpecsTest.php` (7 testów: specy Fun/Classic, inwariant TorpedoSpec, promień ponad spec → wyjątek bez zużycia, domyślny/mniejszy krzyż)
- `make test-unit` 42 ✓, `make test-int` 2 ✓, `make test-func` 18 ✓; `make stan` i cs-fixer czyste

🤖 Generated with [Claude Code](https://claude.com/claude-code)