### PR TITLE
Add Expedition context: captain profile, islands, XP and rank gating

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,8 +19,10 @@ services:
     # Infrastructure bindings
 #    App\Application\Ports\GameRepository: '@App\Infrastructure\Persistence\Doctrine\DoctrineGameRepository'
     App\Domain\Game\GameRepository: '@App\Infrastructure\Persistence\Doctrine\DoctrineGameRepository'
+    App\Domain\Expedition\ProfileRepository: '@App\Infrastructure\Persistence\Doctrine\DoctrineProfileRepository'
 
     # Domain ports
+    App\Domain\Expedition\IslandCatalog: '@App\Domain\Expedition\StaticIslandCatalog'
     App\Domain\Game\FleetGenerator: '@App\Domain\Game\RandomFleetGenerator'
     App\Application\Game\WeaponUseDecider: '@App\Application\Game\RandomWeaponUseDecider'
 

--- a/migrations/Version20260711210536.php
+++ b/migrations/Version20260711210536.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260711210536 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Expedition: tabela profiles (profil kapitana jako snapshot JSON, wzór games)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE profiles (id UUID NOT NULL, state JSON NOT NULL, version INT NOT NULL, created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('COMMENT ON COLUMN profiles.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN profiles.created_at IS \'(DC2Type:datetimetz_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE profiles');
+    }
+}

--- a/src/Application/Expedition/CreateProfile.php
+++ b/src/Application/Expedition/CreateProfile.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Application\Expedition;
+
+use App\Domain\Expedition\CaptainProfile;
+use App\Domain\Expedition\ProfileRepository;
+
+final class CreateProfile
+{
+    public function __construct(private ProfileRepository $profiles)
+    {
+    }
+
+    public function handle(?string $name): CaptainProfile
+    {
+        $profile = CaptainProfile::create($name ?? 'Rozbitek');
+        $this->profiles->save($profile);
+
+        return $profile;
+    }
+}

--- a/src/Application/Expedition/GetExpedition.php
+++ b/src/Application/Expedition/GetExpedition.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Application\Expedition;
+
+use App\Domain\Expedition\IslandCatalog;
+use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Shared\ProfileId;
+
+final class GetExpedition
+{
+    public function __construct(
+        private ProfileRepository $profiles,
+        private IslandCatalog $islands,
+    ) {
+    }
+
+    /**
+     * Stan wyprawy: profil (XP, ranga, postęp do następnej) + wyspy z kłódkami.
+     *
+     * @return array{profile: array<string,mixed>, islands: list<array<string,mixed>>}
+     */
+    public function handle(string $profileId): array
+    {
+        $profile = $this->profiles->get(new ProfileId($profileId));
+        if (null === $profile) {
+            throw new \DomainException('Profile not found');
+        }
+
+        $rank = $profile->rank();
+        $next = $rank->next();
+
+        $islands = [];
+        foreach ($this->islands->all() as $island) {
+            $stats = $profile->battleStats($island->id);
+            $islands[] = [
+                'id' => $island->id,
+                'name' => $island->name,
+                'description' => $island->description,
+                'mode' => $island->mode,
+                'requiredRank' => $island->requiredRank->value,
+                'xpWin' => $island->xpWin,
+                'xpLoss' => $island->xpLoss,
+                'unlocked' => $island->isAccessibleFor($rank),
+                'wins' => $stats['wins'],
+                'losses' => $stats['losses'],
+            ];
+        }
+
+        return [
+            'profile' => [
+                'id' => (string) $profile->id(),
+                'name' => $profile->name(),
+                'xp' => $profile->xp(),
+                'rank' => $rank->value,
+                'nextRank' => null !== $next
+                    ? ['rank' => $next->value, 'xpNeeded' => max(0, $next->threshold() - $profile->xp())]
+                    : null,
+            ],
+            'islands' => $islands,
+        ];
+    }
+}

--- a/src/Application/Expedition/SettleBattle.php
+++ b/src/Application/Expedition/SettleBattle.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Application\Expedition;
+
+use App\Domain\Expedition\IslandCatalog;
+use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Game\GameRepository;
+use App\Domain\Game\GameStatus;
+use App\Domain\Shared\GameId;
+use App\Domain\Shared\ProfileId;
+
+final class SettleBattle
+{
+    public function __construct(
+        private ProfileRepository $profiles,
+        private GameRepository $games,
+        private IslandCatalog $islands,
+    ) {
+    }
+
+    /**
+     * Rozlicza zakończoną bitwę: wynik czytany ze stanu gry (nie od klienta),
+     * XP wg definicji wyspy, idempotentnie (ponowne wywołanie → awarded 0).
+     *
+     * @return array{result:string, awarded:int, xp:int, rank:string, rankUp:bool}
+     */
+    public function handle(string $profileId, string $gameId): array
+    {
+        $profile = $this->profiles->get(new ProfileId($profileId));
+        if (null === $profile) {
+            throw new \DomainException('Profile not found');
+        }
+
+        $game = $this->games->get(new GameId($gameId));
+        if (null === $game) {
+            throw new \DomainException('Game not found');
+        }
+
+        $islandId = $profile->islandFor($game->id());
+        if (null === $islandId) {
+            throw new \DomainException('Battle not registered for this profile');
+        }
+
+        $island = $this->islands->byId($islandId);
+        if (null === $island) {
+            throw new \DomainException('Island not found');
+        }
+
+        if (!$game->isFinished()) {
+            throw new \DomainException('Battle not finished yet');
+        }
+
+        $result = GameStatus::Lost === $game->status() ? 'lost' : 'won';
+        $rankBefore = $profile->rank();
+
+        $awarded = $profile->settleBattle(
+            $game->id(),
+            $result,
+            'won' === $result ? $island->xpWin : $island->xpLoss,
+        );
+        $this->profiles->save($profile);
+
+        return [
+            'result' => $result,
+            'awarded' => $awarded,
+            'xp' => $profile->xp(),
+            'rank' => $profile->rank()->value,
+            'rankUp' => $awarded > 0 && $profile->rank() !== $rankBefore,
+        ];
+    }
+}

--- a/src/Application/Expedition/StartIslandBattle.php
+++ b/src/Application/Expedition/StartIslandBattle.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Application\Expedition;
+
+use App\Application\Game\CreateGame;
+use App\Domain\Expedition\IslandCatalog;
+use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Game\Game;
+use App\Domain\Shared\ProfileId;
+
+final class StartIslandBattle
+{
+    public function __construct(
+        private ProfileRepository $profiles,
+        private IslandCatalog $islands,
+        private CreateGame $createGame,
+    ) {
+    }
+
+    /**
+     * Rozpoczyna bitwę o wyspę: waliduje rangę, tworzy grę wg zasad wyspy
+     * i rejestruje bitwę w profilu. Dalej działa zwykły flow gry (fleet/shots).
+     */
+    public function handle(string $profileId, string $islandId): Game
+    {
+        $profile = $this->profiles->get(new ProfileId($profileId));
+        if (null === $profile) {
+            throw new \DomainException('Profile not found');
+        }
+
+        $island = $this->islands->byId($islandId);
+        if (null === $island) {
+            throw new \DomainException('Island not found');
+        }
+
+        if (!$island->isAccessibleFor($profile->rank())) {
+            throw new \DomainException(sprintf('Island locked: requires rank %s', $island->requiredRank->value));
+        }
+
+        $game = $this->createGame->handle(null, null, $island->mode);
+        $profile->startBattle($island->id, $game->id());
+        $this->profiles->save($profile);
+
+        return $game;
+    }
+}

--- a/src/Domain/Expedition/CaptainProfile.php
+++ b/src/Domain/Expedition/CaptainProfile.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+use App\Domain\Shared\GameId;
+use App\Domain\Shared\ProfileId;
+
+/**
+ * Profil kapitana: doświadczenie i rejestr bitew wypraw. Inwarianty:
+ * XP nigdy nie maleje (doświadczenia się nie traci, także po porażce),
+ * a każda bitwa jest rozliczana dokładnie raz.
+ */
+final class CaptainProfile
+{
+    /** @var array<string, array{island: string, settled: bool, result: ?string}> klucz: gameId */
+    private array $battles = [];
+
+    private function __construct(
+        private ProfileId $id,
+        private string $name,
+        private int $xp = 0,
+    ) {
+    }
+
+    public static function create(string $name): self
+    {
+        $name = trim($name);
+        if ('' === $name || mb_strlen($name) > 40) {
+            throw new \InvalidArgumentException('Profile name must be 1-40 characters');
+        }
+
+        return new self(ProfileId::new(), $name);
+    }
+
+    public function id(): ProfileId
+    {
+        return $this->id;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function xp(): int
+    {
+        return $this->xp;
+    }
+
+    public function rank(): Rank
+    {
+        return Rank::fromXp($this->xp);
+    }
+
+    /** Rejestruje rozpoczętą bitwę o wyspę (jedna gra = jedna bitwa). */
+    public function startBattle(string $islandId, GameId $gameId): void
+    {
+        $key = (string) $gameId;
+        if (isset($this->battles[$key])) {
+            throw new \DomainException('Battle already registered');
+        }
+
+        $this->battles[$key] = ['island' => $islandId, 'settled' => false, 'result' => null];
+    }
+
+    /** Wyspa, o którą toczy się dana gra; null gdy gra nie należy do profilu. */
+    public function islandFor(GameId $gameId): ?string
+    {
+        return $this->battles[(string) $gameId]['island'] ?? null;
+    }
+
+    /**
+     * Rozlicza bitwę i przyznaje XP; zwraca przyznane XP (0 gdy już rozliczona —
+     * rozliczenie jest idempotentne).
+     */
+    public function settleBattle(GameId $gameId, string $result, int $xpAward): int
+    {
+        if (!in_array($result, ['won', 'lost'], true)) {
+            throw new \InvalidArgumentException('Result must be won|lost');
+        }
+        if ($xpAward < 0) {
+            throw new \InvalidArgumentException('Negative XP award');
+        }
+
+        $key = (string) $gameId;
+        $battle = $this->battles[$key] ?? throw new \DomainException('Battle not registered for this profile');
+        if ($battle['settled']) {
+            return 0;
+        }
+
+        $this->battles[$key] = ['island' => $battle['island'], 'settled' => true, 'result' => $result];
+        $this->xp += $xpAward;
+
+        return $xpAward;
+    }
+
+    /** @return array{wins:int, losses:int} rozliczone bitwy o daną wyspę */
+    public function battleStats(string $islandId): array
+    {
+        $wins = 0;
+        $losses = 0;
+        foreach ($this->battles as $battle) {
+            if ($battle['island'] !== $islandId || !$battle['settled']) {
+                continue;
+            }
+            'won' === $battle['result'] ? ++$wins : ++$losses;
+        }
+
+        return ['wins' => $wins, 'losses' => $losses];
+    }
+
+    // --- Snapshot (mapper persystencji) ---
+
+    /** @return array<string, array{island: string, settled: bool, result: ?string}> */
+    public function battles(): array
+    {
+        return $this->battles;
+    }
+
+    /** @param array<string, array{island: string, settled: bool, result: ?string}> $battles */
+    public static function fromSnapshot(ProfileId $id, string $name, int $xp, array $battles): self
+    {
+        $self = new self($id, $name, max(0, $xp));
+        $self->battles = $battles;
+
+        return $self;
+    }
+}

--- a/src/Domain/Expedition/Island.php
+++ b/src/Domain/Expedition/Island.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+/**
+ * Definicja wyspy wyprawy: bitwa o zadanych zasadach, bramkowana rangą,
+ * z nagrodą XP za wygraną i (mniejszą) za przegraną — z porażek też się uczymy.
+ */
+final class Island
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly string $description,
+        public readonly Rank $requiredRank,
+        public readonly string $mode, // 'classic' | 'fun' — wariant zasad bitwy
+        public readonly int $xpWin,
+        public readonly int $xpLoss,
+    ) {
+        if (!in_array($mode, ['classic', 'fun'], true)) {
+            throw new \InvalidArgumentException('Island mode must be classic|fun');
+        }
+        if ($xpWin < 0 || $xpLoss < 0 || $xpLoss > $xpWin) {
+            throw new \InvalidArgumentException('Invalid island XP rewards');
+        }
+    }
+
+    public function isAccessibleFor(Rank $rank): bool
+    {
+        return $rank->atLeast($this->requiredRank);
+    }
+}

--- a/src/Domain/Expedition/IslandCatalog.php
+++ b/src/Domain/Expedition/IslandCatalog.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+interface IslandCatalog
+{
+    /** @return list<Island> wyspy w kolejności wyprawy */
+    public function all(): array;
+
+    public function byId(string $id): ?Island;
+}

--- a/src/Domain/Expedition/ProfileRepository.php
+++ b/src/Domain/Expedition/ProfileRepository.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+use App\Domain\Shared\ProfileId;
+
+interface ProfileRepository
+{
+    public function save(CaptainProfile $profile): void;
+
+    public function get(ProfileId $id): ?CaptainProfile;
+}

--- a/src/Domain/Expedition/Rank.php
+++ b/src/Domain/Expedition/Rank.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+/**
+ * Ranga kapitana wynikająca wprost z XP (progi rosnące). XP nigdy nie ginie,
+ * więc ranga też nie spada. Bramkuje dostęp do wysp (docelowo też typów statków).
+ */
+enum Rank: string
+{
+    case Rozbitek = 'rozbitek';
+    case Marynarz = 'marynarz';
+    case Kapitan = 'kapitan';
+    case Admiral = 'admiral';
+
+    /** Minimalny XP wymagany dla rangi. */
+    public function threshold(): int
+    {
+        return match ($this) {
+            self::Rozbitek => 0,
+            self::Marynarz => 80,
+            self::Kapitan => 250,
+            self::Admiral => 500,
+        };
+    }
+
+    public static function fromXp(int $xp): self
+    {
+        $rank = self::Rozbitek;
+        foreach (self::ordered() as $candidate) {
+            if ($xp >= $candidate->threshold()) {
+                $rank = $candidate;
+            }
+        }
+
+        return $rank;
+    }
+
+    /** @return list<self> rangi od najniższej do najwyższej */
+    public static function ordered(): array
+    {
+        return [self::Rozbitek, self::Marynarz, self::Kapitan, self::Admiral];
+    }
+
+    public function atLeast(self $required): bool
+    {
+        return $this->threshold() >= $required->threshold();
+    }
+
+    /** Następna ranga do zdobycia; null dla najwyższej. */
+    public function next(): ?self
+    {
+        $ordered = self::ordered();
+        $index = array_search($this, $ordered, true);
+
+        return $ordered[$index + 1] ?? null;
+    }
+}

--- a/src/Domain/Expedition/StaticIslandCatalog.php
+++ b/src/Domain/Expedition/StaticIslandCatalog.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+/**
+ * Stały katalog wysp plastra A: liniowa trasa 6 wysp, kolejne bramkowane rangą.
+ * Docelowo (plaster C) katalog będzie generowany z seeda świata.
+ */
+final class StaticIslandCatalog implements IslandCatalog
+{
+    /** @var list<Island>|null */
+    private ?array $islands = null;
+
+    public function all(): array
+    {
+        return $this->islands ??= [
+            new Island(
+                id: 'zatoka-rozbitka',
+                name: 'Zatoka Rozbitka',
+                description: 'Spokojne wody, na których uczysz się fachu. Ktoś tu jednak też ocalał — i nie chce się dzielić zatoką.',
+                requiredRank: Rank::Rozbitek,
+                mode: 'classic',
+                xpWin: 40,
+                xpLoss: 10,
+            ),
+            new Island(
+                id: 'mielizny',
+                name: 'Mielizny',
+                description: 'Płytkie wody i wraki dawnych flot. Miejscowi znają każdą łachę piachu — Ty jeszcze nie.',
+                requiredRank: Rank::Rozbitek,
+                mode: 'classic',
+                xpWin: 50,
+                xpLoss: 12,
+            ),
+            new Island(
+                id: 'wyspa-sygnalowa',
+                name: 'Wyspa Sygnałowa',
+                description: 'Stara stacja nasłuchowa wciąż działa. Tu po raz pierwszy usłyszysz ping sonaru — swój i cudzy.',
+                requiredRank: Rank::Marynarz,
+                mode: 'fun',
+                xpWin: 70,
+                xpLoss: 15,
+            ),
+            new Island(
+                id: 'archipelag-mgiel',
+                name: 'Archipelag Mgieł',
+                description: 'Wyspy, które znikają z map. Walka w gęstej mgle wymaga zimnej krwi i pełnego arsenału.',
+                requiredRank: Rank::Marynarz,
+                mode: 'fun',
+                xpWin: 80,
+                xpLoss: 20,
+            ),
+            new Island(
+                id: 'ciesnina-sztormow',
+                name: 'Cieśnina Sztormów',
+                description: 'Wąskie gardło szlaku handlowego. Kto trzyma cieśninę, trzyma całe morze — dlatego wszyscy o nią walczą.',
+                requiredRank: Rank::Kapitan,
+                mode: 'fun',
+                xpWin: 100,
+                xpLoss: 25,
+            ),
+            new Island(
+                id: 'twierdza-admiralicji',
+                name: 'Twierdza Admiralicji',
+                description: 'Ostatni bastion starej floty. Pokonaj garnizon twierdzy, a nikt nie odmówi Ci szarży admiralskiej.',
+                requiredRank: Rank::Kapitan,
+                mode: 'fun',
+                xpWin: 120,
+                xpLoss: 30,
+            ),
+        ];
+    }
+
+    public function byId(string $id): ?Island
+    {
+        foreach ($this->all() as $island) {
+            if ($island->id === $id) {
+                return $island;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Domain/Shared/ProfileId.php
+++ b/src/Domain/Shared/ProfileId.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Domain\Shared;
+
+use Symfony\Component\Uid\Uuid;
+
+final class ProfileId
+{
+    public function __construct(private string $value)
+    {
+        if (!Uuid::isValid($value)) {
+            throw new \InvalidArgumentException('Invalid UUID');
+        }
+    }
+
+    public static function new(): self
+    {
+        return new self(Uuid::v4()->toRfc4122());
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Infrastructure/Http/Controller/ExpeditionController.php
+++ b/src/Infrastructure/Http/Controller/ExpeditionController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Infrastructure\Http\Controller;
+
+use App\Application\Expedition\CreateProfile;
+use App\Application\Expedition\GetExpedition;
+use App\Application\Expedition\SettleBattle;
+use App\Application\Expedition\StartIslandBattle;
+use App\Infrastructure\Http\Error\ApiException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Uid\Uuid;
+
+#[Route('/api/profiles')]
+final class ExpeditionController
+{
+    public function __construct(
+        private CreateProfile $createProfile,
+        private GetExpedition $getExpedition,
+        private StartIslandBattle $startIslandBattle,
+        private SettleBattle $settleBattle,
+    ) {
+    }
+
+    #[Route('', name: 'api_profiles_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $payload = json_decode($request->getContent() ?: '{}', true);
+        if (!is_array($payload)) {
+            throw new ApiException('Invalid JSON', 'VALIDATION_ERROR', 400);
+        }
+
+        $name = $payload['name'] ?? null;
+        if (null !== $name && !is_string($name)) {
+            throw new ApiException('Invalid field: name:string', 'VALIDATION_ERROR', 400);
+        }
+
+        $profile = $this->createProfile->handle($name);
+
+        return new JsonResponse([
+            'id' => (string) $profile->id(),
+            'name' => $profile->name(),
+            'xp' => $profile->xp(),
+            'rank' => $profile->rank()->value,
+        ], 201);
+    }
+
+    #[Route('/{id}/expedition', name: 'api_profiles_expedition', methods: ['GET'])]
+    public function expedition(string $id): JsonResponse
+    {
+        $this->assertUuid($id, 'profile');
+
+        return new JsonResponse($this->getExpedition->handle($id));
+    }
+
+    #[Route('/{id}/islands/{islandId}/battle', name: 'api_profiles_island_battle', methods: ['POST'])]
+    public function startBattle(string $id, string $islandId): JsonResponse
+    {
+        $this->assertUuid($id, 'profile');
+
+        $game = $this->startIslandBattle->handle($id, $islandId);
+
+        // Ten sam kształt co POST /api/games — frontend wchodzi w zwykły flow gry
+        return new JsonResponse([
+            'id' => (string) $game->id(),
+            'status' => $game->status()->value,
+            'ruleset' => $game->ruleset()->name(),
+            'board' => [
+                'w' => $game->ruleset()->boardSize()->width,
+                'h' => $game->ruleset()->boardSize()->height,
+            ],
+        ], 201);
+    }
+
+    #[Route('/{id}/battles/{gameId}/settle', name: 'api_profiles_battle_settle', methods: ['POST'])]
+    public function settle(string $id, string $gameId): JsonResponse
+    {
+        $this->assertUuid($id, 'profile');
+        $this->assertUuid($gameId, 'game');
+
+        return new JsonResponse($this->settleBattle->handle($id, $gameId));
+    }
+
+    private function assertUuid(string $id, string $what): void
+    {
+        if (!Uuid::isValid($id)) {
+            throw new ApiException(sprintf('Invalid %s id', $what), 'VALIDATION_ERROR', 400);
+        }
+    }
+}

--- a/src/Infrastructure/Http/Error/ExceptionSubscriber.php
+++ b/src/Infrastructure/Http/Error/ExceptionSubscriber.php
@@ -89,6 +89,11 @@ final class ExceptionSubscriber implements EventSubscriberInterface
             return ['TORPEDO_LAUNCH_INVALID', 422];
         }
 
+        // Wyprawa: wyspa zamknięta rangą (komunikat niesie wymaganą rangę)
+        if (str_starts_with($message, 'Island locked')) {
+            return ['ISLAND_LOCKED', 403];
+        }
+
         return match ($message) {
             'Fleet not placed' => ['FLEET_NOT_PLACED', 422],
             'Opponent fleet not placed' => ['FLEET_NOT_PLACED', 422],
@@ -96,6 +101,10 @@ final class ExceptionSubscriber implements EventSubscriberInterface
             'Fleet already placed' => ['VALIDATION_ERROR', 409],
             'Not player turn' => ['NOT_PLAYER_TURN', 409],
             'Game already finished' => ['GAME_ALREADY_FINISHED', 409],
+            'Profile not found' => ['PROFILE_NOT_FOUND', 404],
+            'Island not found' => ['ISLAND_NOT_FOUND', 404],
+            'Battle not registered for this profile' => ['BATTLE_NOT_REGISTERED', 404],
+            'Battle not finished yet' => ['BATTLE_NOT_FINISHED', 409],
             default => ['VALIDATION_ERROR', 400],
         };
     }

--- a/src/Infrastructure/Persistence/Doctrine/DoctrineProfileRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/DoctrineProfileRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Infrastructure\Persistence\Doctrine;
+
+use App\Domain\Expedition\CaptainProfile;
+use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Shared\ProfileId;
+use App\Infrastructure\Persistence\Doctrine\Entity\ProfileRecord;
+use App\Infrastructure\Persistence\Doctrine\Mapper\ProfileSnapshotMapper;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class DoctrineProfileRepository implements ProfileRepository
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ProfileSnapshotMapper $mapper,
+    ) {
+    }
+
+    public function save(CaptainProfile $profile): void
+    {
+        $id = (string) $profile->id();
+
+        /** @var ProfileRecord|null $found */
+        $found = $this->em->find(ProfileRecord::class, $id);
+
+        if ($found) {
+            $found->setState($this->mapper->toArray($profile));
+        } else {
+            $found = new ProfileRecord($id, $this->mapper->toArray($profile));
+            $this->em->persist($found);
+        }
+        $this->em->flush();
+    }
+
+    public function get(ProfileId $id): ?CaptainProfile
+    {
+        /** @var ProfileRecord|null $rec */
+        $rec = $this->em->find(ProfileRecord::class, (string) $id);
+        if (!$rec) {
+            return null;
+        }
+
+        return $this->mapper->toDomain($rec->id(), $rec->state());
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Entity/ProfileRecord.php
+++ b/src/Infrastructure/Persistence/Doctrine/Entity/ProfileRecord.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Infrastructure\Persistence\Doctrine\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'profiles')]
+class ProfileRecord
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
+    private string $id;
+
+    #[ORM\Column(type: Types::JSON, nullable: false)]
+    private array $state = [];
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $version = 1;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIMETZ_MUTABLE)]
+    private \DateTime $updatedAt;
+
+    public function __construct(string $id, array $state)
+    {
+        $this->id = $id;
+        $this->state = $state;
+        $this->createdAt = new \DateTimeImmutable('now');
+        $this->updatedAt = new \DateTime('now');
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function state(): array
+    {
+        return $this->state;
+    }
+
+    public function version(): int
+    {
+        return $this->version;
+    }
+
+    public function setState(array $state): void
+    {
+        $this->state = $state;
+        ++$this->version;
+        $this->updatedAt = new \DateTime('now');
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Mapper/ProfileSnapshotMapper.php
+++ b/src/Infrastructure/Persistence/Doctrine/Mapper/ProfileSnapshotMapper.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Infrastructure\Persistence\Doctrine\Mapper;
+
+use App\Domain\Expedition\CaptainProfile;
+use App\Domain\Shared\ProfileId;
+
+final class ProfileSnapshotMapper
+{
+    /** @return array{name: string, xp: int, battles: array<string, array{island:string, settled:bool, result:?string}>} */
+    public function toArray(CaptainProfile $profile): array
+    {
+        return [
+            'name' => $profile->name(),
+            'xp' => $profile->xp(),
+            'battles' => $profile->battles(),
+        ];
+    }
+
+    /** @param array<string,mixed> $state */
+    public function toDomain(string $id, array $state): CaptainProfile
+    {
+        $battles = [];
+        foreach ((array) ($state['battles'] ?? []) as $gameId => $battle) {
+            if (!is_array($battle) || !isset($battle['island'])) {
+                continue;
+            }
+            $battles[(string) $gameId] = [
+                'island' => (string) $battle['island'],
+                'settled' => (bool) ($battle['settled'] ?? false),
+                'result' => isset($battle['result']) ? (string) $battle['result'] : null,
+            ];
+        }
+
+        return CaptainProfile::fromSnapshot(
+            new ProfileId($id),
+            (string) ($state['name'] ?? 'Rozbitek'),
+            (int) ($state['xp'] ?? 0),
+            $battles,
+        );
+    }
+}

--- a/tests/Functional/ExpeditionApiTest.php
+++ b/tests/Functional/ExpeditionApiTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional;
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Support\FleetFactory;
+
+final class ExpeditionApiTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    public function testFullExpeditionLoop(): void
+    {
+        $client = static::createClient();
+
+        // 1) profil kapitana
+        $profile = $this->post($client, '/api/profiles', ['name' => 'Jacek']);
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('rozbitek', $profile['rank']);
+        self::assertSame(0, $profile['xp']);
+        $profileId = $profile['id'];
+
+        // 2) stan wyprawy: pierwsza wyspa otwarta, ostatnia zamknięta
+        $client->request('GET', "/api/profiles/$profileId/expedition");
+        self::assertResponseIsSuccessful();
+        $expedition = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $islands = $expedition['islands'];
+        self::assertSame('zatoka-rozbitka', $islands[0]['id']);
+        self::assertTrue($islands[0]['unlocked']);
+        self::assertFalse(end($islands)['unlocked']);
+        self::assertSame(['rank' => 'marynarz', 'xpNeeded' => 80], $expedition['profile']['nextRank']);
+
+        // 3) zamknięta wyspa → 403 ISLAND_LOCKED
+        $lockedId = end($islands)['id'];
+        $this->post($client, "/api/profiles/$profileId/islands/$lockedId/battle");
+        self::assertResponseStatusCodeSame(403);
+
+        // 4) bitwa o pierwszą wyspę (classic)
+        $battle = $this->post($client, "/api/profiles/$profileId/islands/zatoka-rozbitka/battle");
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('classic', $battle['ruleset']);
+        $gameId = $battle['id'];
+
+        // 5) rozliczenie przed końcem bitwy → 409
+        $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
+        self::assertResponseStatusCodeSame(409);
+
+        // 6) wystaw flotę i zatop całą flotę przeciwnika (deterministyczna w env test)
+        $fleet = FleetFactory::classic10x10Array();
+        $this->post($client, "/api/games/$gameId/fleet", ['ships' => $fleet]);
+        self::assertResponseIsSuccessful();
+
+        foreach ($fleet as $s) {
+            $horiz = 'h' === strtolower((string) $s['o']);
+            for ($i = 0; $i < $s['l']; ++$i) {
+                $this->post($client, "/api/games/$gameId/shots", [
+                    'x' => $s['x'] + ($horiz ? $i : 0),
+                    'y' => $s['y'] + ($horiz ? 0 : $i),
+                ]);
+                self::assertResponseIsSuccessful();
+            }
+        }
+
+        // 7) rozliczenie: XP za wygraną wg wyspy
+        $settled = $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
+        self::assertResponseIsSuccessful();
+        self::assertSame('won', $settled['result']);
+        self::assertSame(40, $settled['awarded']);
+        self::assertSame(40, $settled['xp']);
+        self::assertSame('rozbitek', $settled['rank']);
+        self::assertFalse($settled['rankUp']);
+
+        // 8) idempotencja: drugie rozliczenie bez XP
+        $again = $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
+        self::assertResponseIsSuccessful();
+        self::assertSame(0, $again['awarded']);
+        self::assertSame(40, $again['xp']);
+
+        // 9) statystyki wyspy w stanie wyprawy
+        $client->request('GET', "/api/profiles/$profileId/expedition");
+        $expedition = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(1, $expedition['islands'][0]['wins']);
+        self::assertSame(40, $expedition['profile']['xp']);
+    }
+
+    public function testSettleRejectsForeignGame(): void
+    {
+        $client = static::createClient();
+
+        $profileId = $this->post($client, '/api/profiles', [])['id'];
+
+        // gra spoza wyprawy (zwykłe POST /api/games)
+        $gameId = $this->post($client, '/api/games', [])['id'];
+
+        $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    /** @return array<string,mixed> */
+    private function post(KernelBrowser $client, string $url, array $payload = []): array
+    {
+        $client->request(
+            'POST',
+            $url,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload, JSON_THROW_ON_ERROR),
+        );
+
+        return json_decode($client->getResponse()->getContent() ?: '{}', true) ?? [];
+    }
+}

--- a/tests/Unit/CaptainProfileTest.php
+++ b/tests/Unit/CaptainProfileTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Expedition\CaptainProfile;
+use App\Domain\Expedition\Rank;
+use App\Domain\Shared\GameId;
+
+it('startuje jako rozbitek z zerowym XP', function () {
+    $profile = CaptainProfile::create('Jacek');
+
+    expect($profile->xp())->toBe(0)
+        ->and($profile->rank())->toBe(Rank::Rozbitek);
+});
+
+it('odrzuca pustą i za długą nazwę', function (string $name) {
+    CaptainProfile::create($name);
+})->with(['', '   ', str_repeat('x', 41)])->throws(InvalidArgumentException::class);
+
+it('rozlicza wygraną bitwę i nalicza XP', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $profile->startBattle('zatoka-rozbitka', $gameId);
+
+    expect($profile->settleBattle($gameId, 'won', 40))->toBe(40)
+        ->and($profile->xp())->toBe(40)
+        ->and($profile->battleStats('zatoka-rozbitka'))->toBe(['wins' => 1, 'losses' => 0]);
+});
+
+it('nalicza XP także za przegraną — doświadczenia się nie traci', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $profile->startBattle('mielizny', $gameId);
+
+    expect($profile->settleBattle($gameId, 'lost', 12))->toBe(12)
+        ->and($profile->xp())->toBe(12)
+        ->and($profile->battleStats('mielizny'))->toBe(['wins' => 0, 'losses' => 1]);
+});
+
+it('rozliczenie jest idempotentne — druga próba nie daje XP', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $profile->startBattle('zatoka-rozbitka', $gameId);
+    $profile->settleBattle($gameId, 'won', 40);
+
+    expect($profile->settleBattle($gameId, 'won', 40))->toBe(0)
+        ->and($profile->xp())->toBe(40);
+});
+
+it('odrzuca rozliczenie niezarejestrowanej bitwy', function () {
+    CaptainProfile::create('Jacek')->settleBattle(GameId::new(), 'won', 40);
+})->throws(DomainException::class, 'Battle not registered for this profile');
+
+it('odrzuca podwójną rejestrację tej samej gry', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $profile->startBattle('zatoka-rozbitka', $gameId);
+    $profile->startBattle('mielizny', $gameId);
+})->throws(DomainException::class, 'Battle already registered');
+
+it('awansuje wraz z progami XP', function () {
+    $profile = CaptainProfile::create('Jacek');
+
+    foreach (range(1, 2) as $i) {
+        $gameId = GameId::new();
+        $profile->startBattle('zatoka-rozbitka', $gameId);
+        $profile->settleBattle($gameId, 'won', 40);
+    }
+
+    expect($profile->xp())->toBe(80)
+        ->and($profile->rank())->toBe(Rank::Marynarz);
+});
+
+it('round-tripuje przez snapshot', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $profile->startBattle('zatoka-rozbitka', $gameId);
+    $profile->settleBattle($gameId, 'won', 40);
+
+    $restored = CaptainProfile::fromSnapshot($profile->id(), $profile->name(), $profile->xp(), $profile->battles());
+
+    expect($restored->xp())->toBe(40)
+        ->and($restored->battleStats('zatoka-rozbitka'))->toBe(['wins' => 1, 'losses' => 0])
+        ->and($restored->settleBattle($gameId, 'won', 40))->toBe(0);
+});

--- a/tests/Unit/RankTest.php
+++ b/tests/Unit/RankTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Expedition\Rank;
+
+it('wyznacza rangę z XP wg progów', function (int $xp, Rank $expected) {
+    expect(Rank::fromXp($xp))->toBe($expected);
+})->with([
+    [0, Rank::Rozbitek],
+    [79, Rank::Rozbitek],
+    [80, Rank::Marynarz],
+    [249, Rank::Marynarz],
+    [250, Rank::Kapitan],
+    [499, Rank::Kapitan],
+    [500, Rank::Admiral],
+    [10000, Rank::Admiral],
+]);
+
+it('porównuje rangi progami', function () {
+    expect(Rank::Kapitan->atLeast(Rank::Marynarz))->toBeTrue()
+        ->and(Rank::Kapitan->atLeast(Rank::Kapitan))->toBeTrue()
+        ->and(Rank::Rozbitek->atLeast(Rank::Marynarz))->toBeFalse();
+});
+
+it('zna następną rangę, a admirał jest ostatni', function () {
+    expect(Rank::Rozbitek->next())->toBe(Rank::Marynarz)
+        ->and(Rank::Kapitan->next())->toBe(Rank::Admiral)
+        ->and(Rank::Admiral->next())->toBeNull();
+});

--- a/tests/Unit/StaticIslandCatalogTest.php
+++ b/tests/Unit/StaticIslandCatalogTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Expedition\Rank;
+use App\Domain\Expedition\StaticIslandCatalog;
+
+it('trasa jest liniowa: wymagane rangi nie maleją', function () {
+    $islands = (new StaticIslandCatalog())->all();
+
+    expect($islands)->not->toBeEmpty();
+
+    $previous = 0;
+    foreach ($islands as $island) {
+        expect($island->requiredRank->threshold())->toBeGreaterThanOrEqual($previous);
+        $previous = $island->requiredRank->threshold();
+    }
+});
+
+it('pierwsza wyspa jest dostępna dla rozbitka, ostatnia nie', function () {
+    $islands = (new StaticIslandCatalog())->all();
+
+    expect($islands[0]->isAccessibleFor(Rank::Rozbitek))->toBeTrue()
+        ->and(end($islands)->isAccessibleFor(Rank::Rozbitek))->toBeFalse()
+        ->and(end($islands)->isAccessibleFor(Rank::Kapitan))->toBeTrue();
+});
+
+it('znajduje wyspę po id i zwraca null dla nieznanej', function () {
+    $catalog = new StaticIslandCatalog();
+
+    expect($catalog->byId('zatoka-rozbitka')?->name)->toBe('Zatoka Rozbitka')
+        ->and($catalog->byId('atlantyda'))->toBeNull();
+});
+
+it('suma XP za wygrane pozwala osiągnąć rangę admirała z niewielką powtórką', function () {
+    $winXp = array_sum(array_map(fn ($i) => $i->xpWin, (new StaticIslandCatalog())->all()));
+
+    // jedno przejście trasy daje większość drogi do admirała (500 XP)
+    expect($winXp)->toBeGreaterThanOrEqual(400);
+});


### PR DESCRIPTION
Część #31 (Epic A) — **backend pętli wyprawy**: mapa → bitwa → XP → ranga. UI mapy wysp dojedzie w osobnym PR (dopiero po nim zamkniemy #31).

## Co

**Domena `src/Domain/Expedition/`** (nowy kontekst, osobny od `Game`):
- `CaptainProfile` — XP nigdy nie maleje (także za przegrane bitwy — z porażek też się uczymy), rejestr bitew gameId→wyspa, rozliczenie idempotentne
- `Rank` — rozbitek (0) → marynarz (80) → kapitan (250) → admirał (500), ranga wynika wprost z XP
- `Island` + `StaticIslandCatalog` — liniowa trasa 6 wysp (Zatoka Rozbitka → … → Twierdza Admiralicji), kolejne bramkowane rangą; wyspa definiuje wariant zasad bitwy (classic/fun) i nagrody XP (win/loss)

**Aplikacja**: `CreateProfile`, `GetExpedition` (profil + wyspy z kłódkami i statystykami), `StartIslandBattle` (walidacja rangi → gra przez istniejący `CreateGame`), `SettleBattle` (wynik czytany ze stanu gry, nie od klienta; idempotentne)

**Infrastruktura**: tabela `profiles` (snapshot JSON — ten sam wzorzec co `games`) + migracja; `ExpeditionController`:
- `POST /api/profiles`
- `GET /api/profiles/{id}/expedition`
- `POST /api/profiles/{id}/islands/{islandId}/battle` (odpowiedź jak `POST /api/games` — frontend wchodzi w zwykły flow gry)
- `POST /api/profiles/{id}/battles/{gameId}/settle`

Agregat `Game` nietknięty — wyprawa spina się z bitwą wyłącznie przez identyfikatory (zgodnie z GAME_DESIGN: bitwa = czysta funkcja).

## Testy

- Unit: `RankTest` (progi, data-driven), `CaptainProfileTest` (9 scenariuszy: idempotencja, XP za porażkę, awans, snapshot round-trip), `StaticIslandCatalogTest`
- Funkcjonalny `ExpeditionApiTest`: pełna pętla (profil → kłódka 403 → bitwa → settle przed końcem 409 → wygrana → 40 XP → drugi settle 0 → statystyki) + odrzucenie rozliczenia cudzej gry (404)
- `make test-unit` 67 ✓, `make test-int` 2 ✓, `make test-func` 20 ✓; PHPStan i cs-fixer czyste

🤖 Generated with [Claude Code](https://claude.com/claude-code)