### PR TITLE
Add expedition UI: island map, captain profile bar and XP settlement

### DIFF
--- a/frontend/src/api/expeditionApi.ts
+++ b/frontend/src/api/expeditionApi.ts
@@ -1,0 +1,64 @@
+import { http } from './http';
+import type { CreateGameResponse } from './gameApi';
+
+export type RankName = 'rozbitek' | 'marynarz' | 'kapitan' | 'admiral';
+
+export const RANK_LABELS: Record<RankName, string> = {
+    rozbitek: 'Rozbitek',
+    marynarz: 'Marynarz',
+    kapitan: 'Kapitan',
+    admiral: 'Admirał',
+};
+
+export interface ProfileDTO {
+    id: string;
+    name: string;
+    xp: number;
+    rank: RankName;
+}
+
+export interface ExpeditionProfileDTO extends ProfileDTO {
+    nextRank: { rank: RankName; xpNeeded: number } | null;
+}
+
+export interface IslandDTO {
+    id: string;
+    name: string;
+    description: string;
+    mode: 'classic' | 'fun';
+    requiredRank: RankName;
+    xpWin: number;
+    xpLoss: number;
+    unlocked: boolean;
+    wins: number;
+    losses: number;
+}
+
+export interface ExpeditionDTO {
+    profile: ExpeditionProfileDTO;
+    islands: IslandDTO[];
+}
+
+export interface SettleResultDTO {
+    result: 'won' | 'lost';
+    awarded: number;
+    xp: number;
+    rank: RankName;
+    rankUp: boolean;
+}
+
+export async function createProfile(name: string): Promise<ProfileDTO> {
+    return http.post<ProfileDTO>('/profiles', { name });
+}
+
+export async function getExpedition(profileId: string): Promise<ExpeditionDTO> {
+    return http.get<ExpeditionDTO>(`/profiles/${profileId}/expedition`);
+}
+
+export async function startIslandBattle(profileId: string, islandId: string): Promise<CreateGameResponse> {
+    return http.post<CreateGameResponse>(`/profiles/${profileId}/islands/${islandId}/battle`, {});
+}
+
+export async function settleBattle(profileId: string, gameId: string): Promise<SettleResultDTO> {
+    return http.post<SettleResultDTO>(`/profiles/${profileId}/battles/${gameId}/settle`, {});
+}

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -2,7 +2,9 @@
 import GameGameBoard from './GameBoard.vue';
 import { useGame } from '../composables/useGame';
 import { computed, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import { settleBattle, RANK_LABELS, type SettleResultDTO } from '../api/expeditionApi'
+import { clearCurrentBattle, getCurrentBattle } from '../lib/expeditionSession'
 
 // Destrukturyzacja: ref-y stają się top-level, więc template odpakowuje je
 // automatycznie (zagnieżdżone w zwykłym obiekcie NIE są odpakowywane).
@@ -168,12 +170,40 @@ const weaponHint = computed(() => {
 function newGame() {
     router.push({ name: 'home' })
 }
+
+// --- Wyprawa: rozliczenie XP po zakończonej bitwie o wyspę ---
+const route = useRoute();
+const expeditionResult = ref<SettleResultDTO | null>(null);
+const gameOver = computed(() => finished.value || status.value === 'won' || status.value === 'lost');
+
+watch(gameOver, async (over) => {
+    if (!over || expeditionResult.value) return;
+    const battle = getCurrentBattle();
+    if (!battle || battle.gameId !== String(route.params.id)) return;
+    try {
+        // idempotentne po stronie backendu; przy błędzie rozliczy się
+        // przy następnym wejściu na mapę wyprawy (siatka bezpieczeństwa)
+        expeditionResult.value = await settleBattle(battle.profileId, battle.gameId);
+        clearCurrentBattle();
+    } catch {
+        // wpis w localStorage zostaje — mapa wyprawy ponowi rozliczenie
+    }
+}, { immediate: true });
 </script>
 
 <template>
     <!-- Banner końca gry u góry sekcji -->
     <div v-if="finished || status === 'won' || status === 'lost'" class="game-banner" :class="status">
         Koniec gry: {{ status === 'won' ? 'Wygrana' : 'Przegrana' }}
+        <template v-if="expeditionResult">
+            <span class="xp-award">
+                +{{ expeditionResult.awarded }} XP
+                <template v-if="expeditionResult.rankUp">
+                    ⚓ awans: {{ RANK_LABELS[expeditionResult.rank] }}!
+                </template>
+            </span>
+            <router-link class="btn small" :to="{ name: 'expedition' }">Wróć na wyprawę</router-link>
+        </template>
         <button class="btn small" @click="newGame">Nowa gra</button>
     </div>
 
@@ -279,6 +309,8 @@ function newGame() {
 }
 .game-banner.won { background: #e6ffe6; border-color: #b3ffb3; color: #0a5b0a; }
 .game-banner.lost { background: #ffe6e6; border-color: #ffb3b3; color: #7a0a0a; }
+.game-banner .xp-award { font-weight: 700; margin: 0 0.5rem; }
+.game-banner a.btn { text-decoration: none; display: inline-block; }
 .btn.small { margin-left: .75rem; padding: .25rem .5rem; font-size: .9rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
 .boards { display: flex; gap: 20px; align-items: start; }
 .hud { margin-top: .5rem; display: grid; gap: .4rem; }

--- a/frontend/src/lib/expeditionSession.ts
+++ b/frontend/src/lib/expeditionSession.ts
@@ -1,0 +1,47 @@
+// Sesja wyprawy w localStorage: identyfikator profilu kapitana oraz
+// trwająca bitwa (żeby Game.vue wiedział, że po zakończeniu ma rozliczyć XP).
+
+const PROFILE_KEY = 'expedition.profileId';
+const BATTLE_KEY = 'expedition.currentBattle';
+
+export interface CurrentBattle {
+    profileId: string;
+    gameId: string;
+    islandId: string;
+    islandName: string;
+}
+
+export function getProfileId(): string | null {
+    return localStorage.getItem(PROFILE_KEY);
+}
+
+export function setProfileId(id: string): void {
+    localStorage.setItem(PROFILE_KEY, id);
+}
+
+export function clearProfileId(): void {
+    localStorage.removeItem(PROFILE_KEY);
+}
+
+export function getCurrentBattle(): CurrentBattle | null {
+    const raw = localStorage.getItem(BATTLE_KEY);
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed.gameId === 'string' && typeof parsed.profileId === 'string') {
+            return parsed as CurrentBattle;
+        }
+    } catch {
+        // uszkodzony wpis — sprzątamy
+    }
+    localStorage.removeItem(BATTLE_KEY);
+    return null;
+}
+
+export function setCurrentBattle(battle: CurrentBattle): void {
+    localStorage.setItem(BATTLE_KEY, JSON.stringify(battle));
+}
+
+export function clearCurrentBattle(): void {
+    localStorage.removeItem(BATTLE_KEY);
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import Game from '../components/Game.vue'
 const PlaceFleet = () => import('../views/PlaceFleet.vue')
+const Expedition = () => import('../views/Expedition.vue')
 
 // Uwaga: w prod aplikacja będzie pod /frontend/ więc ustaw base:
 const base = import.meta.env.PROD ? '/frontend/' : '/'
@@ -11,6 +12,7 @@ const router = createRouter({
     history: createWebHistory(base),
     routes: [
         { path: '/', name: 'home', component: Home },
+        { path: '/expedition', name: 'expedition', component: Expedition },
         { path: '/place-fleet/:id', name: 'place-fleet', component: PlaceFleet },
         { path: '/game/:id', name: 'game', component: Game },
         { path: '/board', redirect: '/' },

--- a/frontend/src/views/Expedition.vue
+++ b/frontend/src/views/Expedition.vue
@@ -1,0 +1,235 @@
+<template>
+    <main class="p-6 expedition">
+        <h1>⚓ Wyprawa</h1>
+
+        <p v-if="loading" class="muted">Wczytywanie wyprawy…</p>
+        <p v-if="error" class="err">{{ error }}</p>
+
+        <!-- Pierwsza wizyta: załóż profil kapitana -->
+        <section v-if="!loading && needsProfile" class="card intro">
+            <h2>Ocalałeś z katastrofy…</h2>
+            <p>
+                Twój okręt zatonął, ale Ty żyjesz. Z desek wraku skleciłeś tratwę.
+                Czas odbudować flotę — od rozbitka do admirała.
+            </p>
+            <form class="name-form" @submit.prevent="onCreateProfile">
+                <label for="captain-name">Jak się nazywasz, rozbitku?</label>
+                <input
+                    id="captain-name"
+                    v-model.trim="newName"
+                    maxlength="40"
+                    placeholder="Imię kapitana"
+                    autocomplete="off"
+                />
+                <button class="btn" :disabled="creating || newName.length === 0">
+                    {{ creating ? 'Tworzenie…' : 'Wypłyń' }}
+                </button>
+            </form>
+        </section>
+
+        <template v-if="expedition">
+            <!-- Pasek profilu: ranga + postęp XP -->
+            <section class="card profile">
+                <div class="profile-head">
+                    <strong>{{ expedition.profile.name }}</strong>
+                    <span class="rank">{{ rankLabel(expedition.profile.rank) }}</span>
+                </div>
+                <div class="xp-row">
+                    <span>{{ expedition.profile.xp }} XP</span>
+                    <template v-if="expedition.profile.nextRank">
+                        <div class="xp-bar" role="progressbar">
+                            <div class="xp-fill" :style="{ width: xpProgress + '%' }"></div>
+                        </div>
+                        <span class="muted">
+                            do rangi {{ rankLabel(expedition.profile.nextRank.rank) }}:
+                            jeszcze {{ expedition.profile.nextRank.xpNeeded }} XP
+                        </span>
+                    </template>
+                    <span v-else class="muted">najwyższa ranga — morza należą do Ciebie</span>
+                </div>
+            </section>
+
+            <!-- Trwająca bitwa -->
+            <section v-if="pendingBattle" class="card pending">
+                ⚔️ Trwa bitwa o <strong>{{ pendingBattle.islandName }}</strong>.
+                <router-link class="btn" :to="{ name: 'game', params: { id: pendingBattle.gameId } }">
+                    Wróć do bitwy
+                </router-link>
+            </section>
+
+            <!-- Trasa wyprawy -->
+            <ol class="islands">
+                <li
+                    v-for="island in expedition.islands"
+                    :key="island.id"
+                    class="card island"
+                    :class="{ locked: !island.unlocked }"
+                >
+                    <div class="island-head">
+                        <h3>{{ island.unlocked ? '🏝️' : '🔒' }} {{ island.name }}</h3>
+                        <span class="mode-tag">{{ island.mode === 'fun' ? 'bronie specjalne' : 'klasyczna bitwa' }}</span>
+                    </div>
+                    <p class="desc">{{ island.description }}</p>
+                    <div class="island-meta">
+                        <span>🏆 +{{ island.xpWin }} XP</span>
+                        <span class="muted">porażka: +{{ island.xpLoss }} XP</span>
+                        <span v-if="island.wins || island.losses" class="muted">
+                            bilans: {{ island.wins }}W / {{ island.losses }}P
+                        </span>
+                    </div>
+                    <button
+                        v-if="island.unlocked"
+                        class="btn"
+                        :disabled="starting !== null || pendingBattle !== null"
+                        @click="onStartBattle(island)"
+                    >
+                        {{ starting === island.id ? 'Stawianie żagli…' : '⚔️ Bitwa' }}
+                    </button>
+                    <p v-else class="muted">Wymaga rangi: {{ rankLabel(island.requiredRank) }}</p>
+                </li>
+            </ol>
+        </template>
+    </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import {
+    createProfile, getExpedition, settleBattle, startIslandBattle,
+    RANK_LABELS, type ExpeditionDTO, type IslandDTO, type RankName,
+} from '../api/expeditionApi';
+import { ApiError } from '../api/http';
+import {
+    clearCurrentBattle, clearProfileId, getCurrentBattle, getProfileId,
+    setCurrentBattle, setProfileId, type CurrentBattle,
+} from '../lib/expeditionSession';
+
+const router = useRouter();
+
+const loading = ref(true);
+const creating = ref(false);
+const starting = ref<string | null>(null);
+const error = ref('');
+const newName = ref('');
+const needsProfile = ref(false);
+const expedition = ref<ExpeditionDTO | null>(null);
+const pendingBattle = ref<CurrentBattle | null>(null);
+
+const xpProgress = computed(() => {
+    const profile = expedition.value?.profile;
+    if (!profile?.nextRank) return 100;
+    const target = profile.xp + profile.nextRank.xpNeeded;
+    return target > 0 ? Math.min(100, Math.round((profile.xp / target) * 100)) : 0;
+});
+
+function rankLabel(rank: RankName): string {
+    return RANK_LABELS[rank] ?? rank;
+}
+
+onMounted(load);
+
+async function load() {
+    loading.value = true;
+    error.value = '';
+    try {
+        const profileId = getProfileId();
+        if (!profileId) {
+            needsProfile.value = true;
+            return;
+        }
+        await settlePendingBattle(profileId);
+        expedition.value = await getExpedition(profileId);
+    } catch (e: any) {
+        // profil zniknął (np. wyczyszczona baza) — zacznij od nowa
+        if (e instanceof ApiError && e.status === 404) {
+            clearProfileId();
+            clearCurrentBattle();
+            needsProfile.value = true;
+            return;
+        }
+        error.value = e?.message ?? 'Nie udało się wczytać wyprawy';
+    } finally {
+        loading.value = false;
+    }
+}
+
+/**
+ * Siatka bezpieczeństwa: jeśli poprzednia bitwa skończyła się bez rozliczenia
+ * (np. zamknięta karta), rozlicz ją przy wejściu na mapę. Rozliczenie jest
+ * po stronie backendu idempotentne.
+ */
+async function settlePendingBattle(profileId: string) {
+    const battle = getCurrentBattle();
+    pendingBattle.value = null;
+    if (!battle || battle.profileId !== profileId) return;
+    try {
+        await settleBattle(battle.profileId, battle.gameId);
+        clearCurrentBattle();
+    } catch (e: any) {
+        if (e instanceof ApiError && 409 === e.status) {
+            // bitwa wciąż trwa — pokaż powrót do gry
+            pendingBattle.value = battle;
+            return;
+        }
+        // gra nie istnieje / nie należy do profilu — sprzątamy martwy wpis
+        clearCurrentBattle();
+    }
+}
+
+async function onCreateProfile() {
+    creating.value = true;
+    error.value = '';
+    try {
+        const profile = await createProfile(newName.value);
+        setProfileId(profile.id);
+        needsProfile.value = false;
+        expedition.value = await getExpedition(profile.id);
+    } catch (e: any) {
+        error.value = e?.message ?? 'Nie udało się utworzyć profilu';
+    } finally {
+        creating.value = false;
+    }
+}
+
+async function onStartBattle(island: IslandDTO) {
+    const profileId = getProfileId();
+    if (!profileId) return;
+    starting.value = island.id;
+    error.value = '';
+    try {
+        const game = await startIslandBattle(profileId, island.id);
+        setCurrentBattle({ profileId, gameId: game.id, islandId: island.id, islandName: island.name });
+        await router.push({ name: 'place-fleet', params: { id: game.id } });
+    } catch (e: any) {
+        error.value = e?.message ?? 'Nie udało się rozpocząć bitwy';
+        starting.value = null;
+    }
+}
+</script>
+
+<style scoped>
+.expedition { max-width: 720px; }
+h1 { margin-bottom: 0.75rem; }
+.card { border: 1px solid #cbd5e1; border-radius: 8px; padding: 0.9rem 1rem; margin-bottom: 0.9rem; background: #fff; }
+.intro h2 { margin-top: 0; }
+.name-form { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+.name-form input { padding: 0.45rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 6px; }
+.profile-head { display: flex; gap: 0.6rem; align-items: baseline; }
+.rank { color: #1f6feb; font-weight: 600; }
+.xp-row { display: flex; gap: 0.6rem; align-items: center; margin-top: 0.4rem; flex-wrap: wrap; }
+.xp-bar { flex: 1 1 140px; min-width: 120px; height: 8px; background: #e2e8f0; border-radius: 4px; overflow: hidden; }
+.xp-fill { height: 100%; background: #1f6feb; transition: width 0.4s ease; }
+.pending { display: flex; gap: 0.75rem; align-items: center; background: #fff7ed; border-color: #fed7aa; }
+.islands { list-style: none; padding: 0; margin: 0; }
+.island.locked { opacity: 0.6; background: #f8fafc; }
+.island-head { display: flex; justify-content: space-between; align-items: baseline; gap: 0.6rem; }
+.island-head h3 { margin: 0; }
+.mode-tag { font-size: 0.8rem; color: #475569; border: 1px solid #cbd5e1; border-radius: 999px; padding: 0.1rem 0.5rem; white-space: nowrap; }
+.desc { color: #334155; margin: 0.4rem 0 0.5rem; }
+.island-meta { display: flex; gap: 0.9rem; margin-bottom: 0.5rem; flex-wrap: wrap; }
+.btn { padding: 0.45rem 0.9rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; text-decoration: none; display: inline-block; }
+.btn[disabled] { opacity: 0.7; cursor: default; }
+.muted { color: #64748b; font-size: 0.9rem; }
+.err { color: crimson; }
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -27,6 +27,12 @@
         </button>
 
         <p v-if="error" class="err">{{ error }}</p>
+
+        <section class="expedition-teaser">
+            <h2>⚓ Wyprawa</h2>
+            <p>Od rozbitka do admirała: zdobywaj wyspy, XP i kolejne rangi.</p>
+            <router-link class="btn" :to="{ name: 'expedition' }">Wypłyń na wyprawę</router-link>
+        </section>
     </main>
 </template>
 
@@ -60,7 +66,10 @@ h1 { margin-bottom: 0.5rem; }
 .mode { margin: 0.75rem 0 1rem; padding: 0.5rem 0.75rem; border: 1px solid #cbd5e1; border-radius: 6px; display: inline-flex; flex-direction: column; gap: 0.35rem; }
 .mode legend { padding: 0 0.3rem; color: #475569; font-size: 0.9rem; }
 .mode label { cursor: pointer; }
-.btn { padding: 0.5rem 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
+.btn { padding: 0.5rem 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; text-decoration: none; display: inline-block; }
 .btn[disabled] { opacity: 0.7; cursor: default; }
 .err { color: crimson; margin-top: 0.5rem; }
+.expedition-teaser { margin-top: 1.5rem; padding: 0.75rem 1rem; border: 1px solid #cbd5e1; border-radius: 8px; max-width: 28rem; }
+.expedition-teaser h2 { margin: 0 0 0.3rem; font-size: 1.05rem; }
+.expedition-teaser p { margin: 0 0 0.6rem; color: #475569; }
 </style>


### PR DESCRIPTION
Closes #31

Druga połowa Epic A — UI nad backendem z #35 (**stacked PR**: baza to `feature/expedition-core-loop`; po merge #35 GitHub sam przepnie bazę na main).

## Co

- **`/expedition`** — mapa wyprawy: trasa wysp z kłódkami wg rangi, opisy, nagrody XP (wygrana/porażka), bilans bitew per wyspa; pasek profilu (imię, ranga, XP, postęp do następnej rangi)
- **Onboarding rozbitka** — pierwsza wizyta: krótkie intro fabularne + utworzenie profilu kapitana
- **Rozliczenie XP w Game.vue** — po zakończonej bitwie wyprawy banner dostaje `+N XP` (i ewentualny awans) oraz przycisk „Wróć na wyprawę"; siatka bezpieczeństwa: nierozliczona bitwa (np. zamknięta karta) rozlicza się przy wejściu na mapę — settle po stronie backendu jest idempotentny
- Sesja wyprawy (profileId + trwająca bitwa) w localStorage; profil skasowany z bazy → czysty restart onboardingu (404 → nowy profil)
- Home: zajawka wyprawy z linkiem

## Weryfikacja

- `npm run build` (vue-tsc) ✓
- E2E na dev (przeglądarka): onboarding → bitwa o Zatokę Rozbitka → przegrana → banner „+10 XP" → mapa pokazuje 10 XP, „do rangi Marynarz: jeszcze 70 XP", bilans 0W/1P, dalsze wyspy zamknięte 🔒

🤖 Generated with [Claude Code](https://claude.com/claude-code)