### PR TITLE
Make fleet composition a battle parameter

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -26,6 +26,8 @@ export interface GameViewDTO {
     status: 'pending' | 'in_progress' | 'won' | 'lost';
     board: { w: number; h: number };
     ruleset: RulesetName;
+    // skład floty do wystawienia: mapa długość => liczba sztuk (klucze JSON jako stringi)
+    allowedShips?: Record<string, number>;
     weapons: WeaponsState;
     opponentWeapons?: WeaponsState;
     mode: 'standard' | 'nonstandard' | string;

--- a/frontend/src/views/PlaceFleet.vue
+++ b/frontend/src/views/PlaceFleet.vue
@@ -70,24 +70,41 @@ const hint = ref('Kliknij pole, aby postawić kolejny statek. Zmieniaj orientacj
 const width = ref(10)
 const height = ref(10)
 
+// Inwentarz domyślny (flota klasyczna): 1×4, 2×3, 3×2, 4×1;
+// gra może narzucić inny skład (allowedShips z API — flota wyprawy)
+const CLASSIC_INVENTORY = [4,3,3,2,2,2,1,1,1,1]
+
+function inventoryFrom(allowed: Record<string, number>): number[] {
+  const lengths: number[] = []
+  for (const [len, count] of Object.entries(allowed)) {
+    for (let i = 0; i < count; i++) lengths.push(Number(len))
+  }
+  return lengths.sort((a, b) => b - a)
+}
+
 onMounted(async () => {
   try {
     const g = await getGame(id)
     width.value = g.board.w
     height.value = g.board.h
+    if (g.allowedShips && Object.keys(g.allowedShips).length > 0) {
+      fullInventory.value = inventoryFrom(g.allowedShips)
+      inventory.value = [...fullInventory.value]
+    }
   } catch {
-    // zostają domyślne 10×10; błąd i tak wyjdzie przy zapisie floty
+    // zostają domyślne 10×10 i flota klasyczna; błąd i tak wyjdzie przy zapisie floty
   }
 })
 
-// Inwentarz klasyczny: 1×4, 2×3, 3×2, 4×1
-const inventory = ref<number[]>([4,3,3,2,2,2,1,1,1,1])
+const fullInventory = ref<number[]>([...CLASSIC_INVENTORY])
+const inventory = ref<number[]>([...CLASSIC_INVENTORY])
 const placed = ref<PlayerFleetItem[]>([])
 const orientation = ref<'h'|'v'>('h')
 const hoverPos = ref<{x:number,y:number}>({x:-1,y:-1})
 
 const remainingByLen = computed<Record<number, number>>(() => {
-  const left: Record<number, number> = {1:0,2:0,3:0,4:0}
+  const left: Record<number, number> = {}
+  for (const l of fullInventory.value) left[l] = 0
   for (const l of inventory.value) left[l] = (left[l] ?? 0) + 1
   return left
 })
@@ -96,7 +113,7 @@ const allPlaced = computed(() => inventory.value.length === 0)
 
 function resetFleet() {
   placed.value = []
-  inventory.value = [4,3,3,2,2,2,1,1,1,1]
+  inventory.value = [...fullInventory.value]
   error.value = ''
 }
 

--- a/src/Application/Game/CreateGame.php
+++ b/src/Application/Game/CreateGame.php
@@ -14,10 +14,11 @@ final class CreateGame
     {
     }
 
-    public function handle(?int $w = null, ?int $h = null, string $mode = 'classic'): Game
+    /** @param array<int,int>|null $ships skład floty (długość => sztuki); null = flota klasyczna */
+    public function handle(?int $w = null, ?int $h = null, string $mode = 'classic', ?array $ships = null): Game
     {
         $size = new BoardSize($w ?? 10, $h ?? 10);
-        $rules = 'fun' === $mode ? new FunRuleset($size) : new ClassicRuleset($size);
+        $rules = 'fun' === $mode ? new FunRuleset($size, $ships) : new ClassicRuleset($size, $ships);
 
         $game = Game::create($rules);
         $this->repo->save($game);

--- a/src/Domain/Game/ClassicRuleset.php
+++ b/src/Domain/Game/ClassicRuleset.php
@@ -6,8 +6,12 @@ use App\Domain\Game\Weapon\WeaponSpecs;
 
 final class ClassicRuleset implements Ruleset
 {
-    public function __construct(private BoardSize $size = new BoardSize(10, 10))
-    {
+    /** @param array<int,int>|null $ships skład floty: długość => liczba sztuk (null = flota klasyczna) */
+    public function __construct(
+        private BoardSize $size = new BoardSize(10, 10),
+        private ?array $ships = null,
+    ) {
+        FleetComposition::assertValid($ships);
     }
 
     public function name(): string
@@ -22,8 +26,7 @@ final class ClassicRuleset implements Ruleset
 
     public function allowedShips(): array
     {
-        // classic fleet: 1x4, 2x3, 3x2, 4x1
-        return [4 => 1, 3 => 2, 2 => 3, 1 => 4];
+        return $this->ships ?? FleetComposition::CLASSIC;
     }
 
     public function weapons(): WeaponSpecs

--- a/src/Domain/Game/DeterministicFleetGenerator.php
+++ b/src/Domain/Game/DeterministicFleetGenerator.php
@@ -3,14 +3,27 @@
 namespace App\Domain\Game;
 
 /**
- * Stały, poprawny układ klasycznej floty (1x4, 2x3, 3x2, 4x1) w obrębie 10x10.
- * Używany w env testowym (przewidywalne testy funkcjonalne — układ musi być
- * zgodny z Tests\Support\FleetFactory::classic10x10()) oraz jako awaryjny
- * fallback generatora losowego. Mieści się na każdej planszy >= 10x10.
+ * Deterministyczny układ floty. Dla floty klasycznej zwraca stały układ
+ * zgodny z Tests\Support\FleetFactory::classic10x10() (przewidywalne testy
+ * funkcjonalne). Dla niestandardowego składu (skład wyprawy) pakuje statki
+ * wierszami: najdłuższe pierwsze, odstęp 1 pola (statki nie mogą się stykać).
+ * Używany w env testowym oraz jako awaryjny fallback generatora losowego.
  */
 final class DeterministicFleetGenerator implements FleetGenerator
 {
     public function generate(Ruleset $ruleset): array
+    {
+        $composition = $ruleset->allowedShips();
+
+        if (FleetComposition::isClassic($composition)) {
+            return $this->classicLayout();
+        }
+
+        return $this->rowPackedLayout($composition, $ruleset->boardSize());
+    }
+
+    /** @return Ship[] */
+    private function classicLayout(): array
     {
         return [
             new Ship(new Coordinate(0, 0), Orientation::H, 4),
@@ -24,5 +37,34 @@ final class DeterministicFleetGenerator implements FleetGenerator
             new Ship(new Coordinate(5, 9), Orientation::H, 1),
             new Ship(new Coordinate(8, 8), Orientation::H, 1),
         ];
+    }
+
+    /**
+     * @param array<int,int> $composition
+     *
+     * @return Ship[]
+     */
+    private function rowPackedLayout(array $composition, BoardSize $size): array
+    {
+        krsort($composition);
+
+        $ships = [];
+        $x = 0;
+        $y = 0;
+        foreach ($composition as $length => $count) {
+            for ($i = 0; $i < $count; ++$i) {
+                if ($x + $length > $size->width) {
+                    $x = 0;
+                    $y += 2; // pusty wiersz odstępu — statki nie mogą się stykać
+                }
+                if ($y >= $size->height) {
+                    throw new \DomainException('Fleet does not fit on board');
+                }
+                $ships[] = new Ship(new Coordinate($x, $y), Orientation::H, $length);
+                $x += $length + 1;
+            }
+        }
+
+        return $ships;
     }
 }

--- a/src/Domain/Game/FleetComposition.php
+++ b/src/Domain/Game/FleetComposition.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Domain\Game;
+
+/**
+ * Skład floty jako mapa: długość statku => liczba sztuk.
+ * Domyślnym składem jest flota klasyczna; niestandardowe składy
+ * (np. flota wyprawy budowana w stoczniach) przekazuje się do rulesetu.
+ */
+final class FleetComposition
+{
+    /** Flota klasyczna: 1×4, 2×3, 3×2, 4×1. */
+    public const CLASSIC = [4 => 1, 3 => 2, 2 => 3, 1 => 4];
+
+    private const MAX_SHIP_LENGTH = 6;
+    private const MAX_SHIPS_PER_LENGTH = 20;
+
+    /** @param array<int,int>|null $ships */
+    public static function assertValid(?array $ships): void
+    {
+        if (null === $ships) {
+            return;
+        }
+        if ([] === $ships) {
+            throw new \InvalidArgumentException('Fleet composition must not be empty');
+        }
+        foreach ($ships as $length => $count) {
+            if ($length < 1 || $length > self::MAX_SHIP_LENGTH) {
+                throw new \InvalidArgumentException('Invalid ship length in fleet composition');
+            }
+            if ($count < 1 || $count > self::MAX_SHIPS_PER_LENGTH) {
+                throw new \InvalidArgumentException('Invalid ship count in fleet composition');
+            }
+        }
+    }
+
+    /** @param array<int,int> $ships */
+    public static function isClassic(array $ships): bool
+    {
+        ksort($ships);
+        $classic = self::CLASSIC;
+        ksort($classic);
+
+        return $ships === $classic;
+    }
+}

--- a/src/Domain/Game/FunRuleset.php
+++ b/src/Domain/Game/FunRuleset.php
@@ -9,8 +9,12 @@ use App\Domain\Game\Weapon\WeaponSpecs;
 
 final class FunRuleset implements Ruleset
 {
-    public function __construct(private BoardSize $size = new BoardSize(10, 10))
-    {
+    /** @param array<int,int>|null $ships skład floty: długość => liczba sztuk (null = flota klasyczna) */
+    public function __construct(
+        private BoardSize $size = new BoardSize(10, 10),
+        private ?array $ships = null,
+    ) {
+        FleetComposition::assertValid($ships);
     }
 
     public function name(): string
@@ -25,7 +29,7 @@ final class FunRuleset implements Ruleset
 
     public function allowedShips(): array
     {
-        return [4 => 1, 3 => 2, 2 => 3, 1 => 4];
+        return $this->ships ?? FleetComposition::CLASSIC;
     }
 
     public function weapons(): WeaponSpecs

--- a/src/Infrastructure/Http/Controller/GameController.php
+++ b/src/Infrastructure/Http/Controller/GameController.php
@@ -30,7 +30,24 @@ final class GameController
             throw new ApiException('Invalid mode: expected classic|fun', 'VALIDATION_ERROR', 400);
         }
 
-        $game = $this->createGame->handle($w, $h, $mode);
+        // Opcjonalny skład floty: mapa długość => liczba sztuk (brak = flota klasyczna).
+        // Klucze JSON to stringi; walidację wartości robi domena (FleetComposition).
+        $ships = $data['ships'] ?? null;
+        if (null !== $ships) {
+            if (!is_array($ships) || [] === $ships) {
+                throw new ApiException('Invalid ships: expected map {length: count}', 'VALIDATION_ERROR', 400);
+            }
+            $parsed = [];
+            foreach ($ships as $length => $count) {
+                if (!is_int($count)) {
+                    throw new ApiException('Invalid ships: expected map {length: count}', 'VALIDATION_ERROR', 400);
+                }
+                $parsed[(int) $length] = $count;
+            }
+            $ships = $parsed;
+        }
+
+        $game = $this->createGame->handle($w, $h, $mode, $ships);
 
         return new JsonResponse([
             'id' => (string) $game->id(),

--- a/src/Infrastructure/Http/Controller/GameQueryController.php
+++ b/src/Infrastructure/Http/Controller/GameQueryController.php
@@ -87,6 +87,8 @@ final class GameQueryController
             'status' => $game->status()->value,
             'board' => ['w' => $size->width, 'h' => $size->height],
             'ruleset' => $game->ruleset()->name(),
+            // skład floty do wystawienia: mapa długość => liczba sztuk
+            'allowedShips' => $game->ruleset()->allowedShips(),
             'weapons' => $game->weaponsState(),
             'opponentWeapons' => $game->opponentWeaponsState(),
             'mode' => $game->mode(),

--- a/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
+++ b/src/Infrastructure/Persistence/Doctrine/Mapper/GameSnapshotMapper.php
@@ -55,6 +55,7 @@ final class GameSnapshotMapper
             'ruleset' => [
                 'type' => $game->ruleset()->name(),
                 'board' => ['w' => $size->width, 'h' => $size->height],
+                'ships' => $game->ruleset()->allowedShips(),
             ],
             'fleet' => $fleet,
             'shots' => $shots,
@@ -182,9 +183,18 @@ final class GameSnapshotMapper
         $board = $data['board'] ?? ['w' => 10, 'h' => 10];
         $size = new BoardSize((int) $board['w'], (int) $board['h']);
 
+        // Skład floty (klucze JSON wracają jako stringi); brak = flota klasyczna
+        $ships = null;
+        if (!empty($data['ships']) && is_array($data['ships'])) {
+            $ships = [];
+            foreach ($data['ships'] as $length => $count) {
+                $ships[(int) $length] = (int) $count;
+            }
+        }
+
         return 'fun' === ($data['type'] ?? 'classic')
-            ? new FunRuleset($size)
-            : new ClassicRuleset($size);
+            ? new FunRuleset($size, $ships)
+            : new ClassicRuleset($size, $ships);
     }
 
     /** @return array{player: array<string,int>, opponent: array<string,int>}|null */

--- a/tests/Functional/GameApiCustomFleetTest.php
+++ b/tests/Functional/GameApiCustomFleetTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional;
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class GameApiCustomFleetTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    public function testGameWithCustomFleetComposition(): void
+    {
+        $client = static::createClient();
+
+        // 1) gra z niestandardowym składem: 1 dwumasztowiec + 2 tratwy
+        $client->request(
+            'POST',
+            '/api/games',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['mode' => 'classic', 'ships' => [2 => 1, 1 => 2]], JSON_THROW_ON_ERROR)
+        );
+        self::assertResponseStatusCodeSame(201);
+        $id = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR)['id'];
+
+        // 2) GET zwraca skład do wystawienia (klucze JSON jako stringi)
+        $client->request('GET', "/api/games/$id");
+        self::assertResponseIsSuccessful();
+        $view = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['2' => 1, '1' => 2], $view['allowedShips']);
+
+        // 3) flota niezgodna ze składem zostaje odrzucona…
+        $client->request(
+            'POST',
+            "/api/games/$id/fleet",
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['ships' => [
+                ['x' => 0, 'y' => 0, 'o' => 'h', 'l' => 4],
+            ]], JSON_THROW_ON_ERROR)
+        );
+        self::assertResponseStatusCodeSame(422);
+
+        // 4) …a zamówiony skład przechodzi (przeciwnik dostaje ten sam skład
+        //    z deterministycznego generatora w env testowym)
+        $client->request(
+            'POST',
+            "/api/games/$id/fleet",
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['ships' => [
+                ['x' => 0, 'y' => 0, 'o' => 'h', 'l' => 2],
+                ['x' => 4, 'y' => 0, 'o' => 'h', 'l' => 1],
+                ['x' => 6, 'y' => 2, 'o' => 'h', 'l' => 1],
+            ]], JSON_THROW_ON_ERROR)
+        );
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testRejectsInvalidCompositionPayload(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/api/games',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['ships' => [9 => 1]], JSON_THROW_ON_ERROR)
+        );
+        self::assertResponseStatusCodeSame(400);
+    }
+}

--- a/tests/Unit/FleetCompositionTest.php
+++ b/tests/Unit/FleetCompositionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Game\Board;
+use App\Domain\Game\BoardSize;
+use App\Domain\Game\ClassicRuleset;
+use App\Domain\Game\Coordinate;
+use App\Domain\Game\DeterministicFleetGenerator;
+use App\Domain\Game\FleetComposition;
+use App\Domain\Game\FunRuleset;
+use App\Domain\Game\Game;
+use App\Domain\Game\Orientation;
+use App\Domain\Game\Ship;
+use App\Infrastructure\Persistence\Doctrine\Mapper\GameSnapshotMapper;
+
+it('ruleset bez składu zwraca flotę klasyczną', function () {
+    expect((new ClassicRuleset())->allowedShips())->toBe(FleetComposition::CLASSIC)
+        ->and((new FunRuleset())->allowedShips())->toBe(FleetComposition::CLASSIC);
+});
+
+it('ruleset przyjmuje niestandardowy skład floty', function () {
+    $ruleset = new ClassicRuleset(new BoardSize(10, 10), [2 => 1, 1 => 3]);
+
+    expect($ruleset->allowedShips())->toBe([2 => 1, 1 => 3]);
+});
+
+it('odrzuca nieprawidłowy skład floty', function (array $ships) {
+    new ClassicRuleset(new BoardSize(10, 10), $ships);
+})->with([
+    'pusty' => [[]],
+    'zerowa liczba sztuk' => [[2 => 0]],
+    'za długi statek' => [[7 => 1]],
+])->throws(InvalidArgumentException::class);
+
+it('placeFleet waliduje wobec niestandardowego składu', function () {
+    $game = Game::create(new ClassicRuleset(new BoardSize(10, 10), [2 => 1, 1 => 2]));
+
+    $game->placeFleet([
+        new Ship(new Coordinate(0, 0), Orientation::H, 2),
+        new Ship(new Coordinate(4, 0), Orientation::H, 1),
+        new Ship(new Coordinate(6, 2), Orientation::H, 1),
+    ]);
+
+    expect($game->fleet())->toHaveCount(3);
+});
+
+it('placeFleet odrzuca flotę klasyczną przy niestandardowym składzie', function () {
+    $game = Game::create(new ClassicRuleset(new BoardSize(10, 10), [2 => 1, 1 => 2]));
+    $game->placeFleet([
+        new Ship(new Coordinate(0, 0), Orientation::H, 4),
+        new Ship(new Coordinate(0, 2), Orientation::H, 1),
+        new Ship(new Coordinate(4, 4), Orientation::H, 1),
+    ]);
+})->throws(DomainException::class, 'Invalid fleet composition');
+
+it('generator deterministyczny zachowuje stały układ dla floty klasycznej', function () {
+    $ships = (new DeterministicFleetGenerator())->generate(new ClassicRuleset());
+
+    expect($ships)->toHaveCount(10)
+        ->and($ships[0]->start->x)->toBe(0)
+        ->and($ships[0]->start->y)->toBe(0)
+        ->and($ships[0]->length)->toBe(4);
+});
+
+it('generator deterministyczny układa legalnie niestandardowy skład', function () {
+    $ruleset = new FunRuleset(new BoardSize(10, 10), [4 => 1, 3 => 2, 1 => 4]);
+    $ships = (new DeterministicFleetGenerator())->generate($ruleset);
+
+    expect($ships)->toHaveCount(7);
+
+    // legalność układu weryfikuje Board (kolizje, styk, granice)
+    $board = new Board(new BoardSize(10, 10));
+    $board->placeMany($ships);
+
+    // skład zgodny z zamówieniem — waliduje domena
+    $game = Game::create($ruleset);
+    $game->placeFleet($ships);
+    expect($game->fleet())->toHaveCount(7);
+});
+
+it('generator deterministyczny rzuca, gdy skład nie mieści się na planszy', function () {
+    (new DeterministicFleetGenerator())->generate(
+        new ClassicRuleset(new BoardSize(10, 10), [4 => 20])
+    );
+})->throws(DomainException::class, 'Fleet does not fit on board');
+
+it('snapshot round-tripuje niestandardowy skład floty', function () {
+    $mapper = new GameSnapshotMapper();
+    $game = Game::create(new FunRuleset(new BoardSize(10, 10), [2 => 2, 1 => 1]));
+
+    // symulacja JSON: klucze mapy stają się stringami
+    $state = json_decode((string) json_encode($mapper->toArray($game)), true);
+    $restored = $mapper->toDomain((string) $game->id(), $state);
+
+    expect($restored->ruleset()->allowedShips())->toBe([2 => 2, 1 => 1])
+        ->and($restored->ruleset()->name())->toBe('fun');
+});


### PR DESCRIPTION
Część #32 (Epic B, krok 1/3) — skład floty przestaje być zaszyty w rulesecie i staje się parametrem bitwy. Bez tego majątek floty (statki budowane w stoczniach) nie miałby jak wpłynąć na rozgrywkę.

## Co

- **`FleetComposition`** (Domain) — stała `CLASSIC` + walidacja niestandardowych składów (długość 1–6, sztuk 1–20)
- **`ClassicRuleset`/`FunRuleset`** — opcjonalny konstruktor `?array $ships`; `allowedShips()` zwraca skład albo klasykę
- **Snapshot** — `ruleset.ships` zapisywane i odtwarzane (klucze JSON→int); stare snapshoty bez pola = flota klasyczna
- **`DeterministicFleetGenerator`** — dla klasyka stały układ (kontrakt z `FleetFactory` i testami funkcjonalnymi nietknięty), dla innych składów deterministyczne pakowanie wierszowe (statki się nie stykają); skład niemieszczący się na planszy → błąd domenowy
- **API**: `POST /api/games` przyjmuje opcjonalne `ships`, `GET /api/games/{id}` zwraca `allowedShips`; `RandomFleetGenerator` przeciwnika adaptuje się sam (czyta `allowedShips()`)
- **PlaceFleet.vue** — inwentarz budowany z `allowedShips` z API (fallback: klasyka), reset floty wraca do składu gry

Zachowanie dotychczasowych gier bez zmian — dopóki nikt nie poda składu, wszystko działa jak dziś.

## Następne kroki epiku (osobne PR-y)

2. Majątek floty w Expedition: typy statków, stocznie, materiały, straty/remonty po bitwie, skład bitwy = sprawna flota gracza
3. Broń ze składu floty: nalot=lotniskowiec, torpeda=niszczyciel, sonar=zwiadowca

## Testy

- Unit `FleetCompositionTest` (9): walidacja składów, placeFleet wobec niestandardowego składu, stały układ klasyka, legalność pakowania wierszowego (weryfikacja przez `Board`), round-trip snapshotu przez JSON
- Funkcjonalny `GameApiCustomFleetTest`: gra ze składem `{2:1, 1:2}` end-to-end + odrzucenie złego payloadu
- `make test-unit` 78 ✓, `make test-func` 22 ✓, `make test-int` 2 ✓, PHPStan/cs-fixer czyste, `npm run build` (vue-tsc) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)