### PR TITLE
Add fleet as property: ship types, materials, shipyards, battle losses

### DIFF
--- a/src/Application/Expedition/BuildShip.php
+++ b/src/Application/Expedition/BuildShip.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Application\Expedition;
+
+use App\Domain\Expedition\IslandCatalog;
+use App\Domain\Expedition\OwnedShip;
+use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Expedition\ShipType;
+use App\Domain\Shared\ProfileId;
+
+final class BuildShip
+{
+    public function __construct(
+        private ProfileRepository $profiles,
+        private IslandCatalog $islands,
+    ) {
+    }
+
+    /**
+     * Buduje statek w stoczni wyspy: wyspa musi być dostępna (ranga),
+     * stocznia wystarczająco duża, a bramkę rangi typu i koszt materiałów
+     * egzekwuje domena (CaptainProfile::buildShip).
+     */
+    public function handle(string $profileId, string $islandId, ShipType $type): OwnedShip
+    {
+        $profile = $this->profiles->get(new ProfileId($profileId));
+        if (null === $profile) {
+            throw new \DomainException('Profile not found');
+        }
+
+        $island = $this->islands->byId($islandId);
+        if (null === $island) {
+            throw new \DomainException('Island not found');
+        }
+        if (!$island->isAccessibleFor($profile->rank())) {
+            throw new \DomainException(sprintf('Island locked: requires rank %s', $island->requiredRank->value));
+        }
+        if ($island->shipyardLevel < $type->requiredShipyardLevel()) {
+            throw new \DomainException('Shipyard level too low for this ship type');
+        }
+
+        $ship = $profile->buildShip($type);
+        $this->profiles->save($profile);
+
+        return $ship;
+    }
+}

--- a/src/Application/Expedition/GetExpedition.php
+++ b/src/Application/Expedition/GetExpedition.php
@@ -4,6 +4,7 @@ namespace App\Application\Expedition;
 
 use App\Domain\Expedition\IslandCatalog;
 use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Expedition\ShipType;
 use App\Domain\Shared\ProfileId;
 
 final class GetExpedition
@@ -15,9 +16,10 @@ final class GetExpedition
     }
 
     /**
-     * Stan wyprawy: profil (XP, ranga, postęp do następnej) + wyspy z kłódkami.
+     * Stan wyprawy: profil (XP, ranga, materiały), flota, katalog typów
+     * statków (do UI stoczni) i wyspy z kłódkami.
      *
-     * @return array{profile: array<string,mixed>, islands: list<array<string,mixed>>}
+     * @return array{profile: array<string,mixed>, fleet: list<array<string,mixed>>, shipTypes: list<array<string,mixed>>, islands: list<array<string,mixed>>}
      */
     public function handle(string $profileId): array
     {
@@ -40,11 +42,32 @@ final class GetExpedition
                 'requiredRank' => $island->requiredRank->value,
                 'xpWin' => $island->xpWin,
                 'xpLoss' => $island->xpLoss,
+                'materialsWin' => $island->materialsWin,
+                'materialsLoss' => $island->materialsLoss,
+                'shipyardLevel' => $island->shipyardLevel,
+                'board' => ['w' => $island->boardWidth, 'h' => $island->boardHeight],
                 'unlocked' => $island->isAccessibleFor($rank),
                 'wins' => $stats['wins'],
                 'losses' => $stats['losses'],
             ];
         }
+
+        $fleet = array_map(static fn ($ship) => [
+            'id' => $ship->id,
+            'type' => $ship->type->value,
+            'length' => $ship->type->length(),
+            'damaged' => $ship->isDamaged(),
+            'repairCost' => $ship->type->repairCost(),
+        ], $profile->fleet());
+
+        $shipTypes = array_map(static fn (ShipType $type) => [
+            'type' => $type->value,
+            'length' => $type->length(),
+            'buildCost' => $type->buildCost(),
+            'repairCost' => $type->repairCost(),
+            'requiredRank' => $type->requiredRank()->value,
+            'requiredShipyardLevel' => $type->requiredShipyardLevel(),
+        ], ShipType::cases());
 
         return [
             'profile' => [
@@ -55,7 +78,10 @@ final class GetExpedition
                 'nextRank' => null !== $next
                     ? ['rank' => $next->value, 'xpNeeded' => max(0, $next->threshold() - $profile->xp())]
                     : null,
+                'materials' => $profile->materials(),
             ],
+            'fleet' => $fleet,
+            'shipTypes' => $shipTypes,
             'islands' => $islands,
         ];
     }

--- a/src/Application/Expedition/RepairShip.php
+++ b/src/Application/Expedition/RepairShip.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Application\Expedition;
+
+use App\Domain\Expedition\IslandCatalog;
+use App\Domain\Expedition\OwnedShip;
+use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Shared\ProfileId;
+
+final class RepairShip
+{
+    public function __construct(
+        private ProfileRepository $profiles,
+        private IslandCatalog $islands,
+    ) {
+    }
+
+    /**
+     * Remontuje statek w stoczni wyspy — te same bramki co budowa
+     * (dostępność wyspy, poziom stoczni), koszt egzekwuje domena.
+     */
+    public function handle(string $profileId, string $islandId, string $shipId): OwnedShip
+    {
+        $profile = $this->profiles->get(new ProfileId($profileId));
+        if (null === $profile) {
+            throw new \DomainException('Profile not found');
+        }
+
+        $island = $this->islands->byId($islandId);
+        if (null === $island) {
+            throw new \DomainException('Island not found');
+        }
+        if (!$island->isAccessibleFor($profile->rank())) {
+            throw new \DomainException(sprintf('Island locked: requires rank %s', $island->requiredRank->value));
+        }
+
+        $ship = null;
+        foreach ($profile->fleet() as $candidate) {
+            if ($candidate->id === $shipId) {
+                $ship = $candidate;
+                break;
+            }
+        }
+        if (null !== $ship && $island->shipyardLevel < $ship->type->requiredShipyardLevel()) {
+            throw new \DomainException('Shipyard level too low for this ship type');
+        }
+
+        $repaired = $profile->repairShip($shipId);
+        $this->profiles->save($profile);
+
+        return $repaired;
+    }
+}

--- a/src/Application/Expedition/SettleBattle.php
+++ b/src/Application/Expedition/SettleBattle.php
@@ -4,6 +4,7 @@ namespace App\Application\Expedition;
 
 use App\Domain\Expedition\IslandCatalog;
 use App\Domain\Expedition\ProfileRepository;
+use App\Domain\Game\Game;
 use App\Domain\Game\GameRepository;
 use App\Domain\Game\GameStatus;
 use App\Domain\Shared\GameId;
@@ -19,10 +20,13 @@ final class SettleBattle
     }
 
     /**
-     * Rozlicza zakończoną bitwę: wynik czytany ze stanu gry (nie od klienta),
-     * XP wg definicji wyspy, idempotentnie (ponowne wywołanie → awarded 0).
+     * Rozlicza zakończoną bitwę: wynik i straty czytane ze stanu gry (nie od
+     * klienta), XP i materiały wg definicji wyspy, idempotentnie (ponowne
+     * wywołanie → zera). Zatopione statki: wygrana → do remontu, przegrana →
+     * stracone.
      *
-     * @return array{result:string, awarded:int, xp:int, rank:string, rankUp:bool}
+     * @return array{result:string, awarded:int, xp:int, rank:string, rankUp:bool,
+     *     materialsAwarded:int, materials:int, lostShips:list<string>, damagedShips:list<string>}
      */
     public function handle(string $profileId, string $gameId): array
     {
@@ -53,19 +57,57 @@ final class SettleBattle
         $result = GameStatus::Lost === $game->status() ? 'lost' : 'won';
         $rankBefore = $profile->rank();
 
-        $awarded = $profile->settleBattle(
+        $outcome = $profile->settleBattle(
             $game->id(),
             $result,
             'won' === $result ? $island->xpWin : $island->xpLoss,
+            'won' === $result ? $island->materialsWin : $island->materialsLoss,
+            $this->sunkPlayerShipLengths($game),
         );
         $this->profiles->save($profile);
 
         return [
             'result' => $result,
-            'awarded' => $awarded,
+            'awarded' => $outcome['xp'],
             'xp' => $profile->xp(),
             'rank' => $profile->rank()->value,
-            'rankUp' => $awarded > 0 && $profile->rank() !== $rankBefore,
+            'rankUp' => $outcome['xp'] > 0 && $profile->rank() !== $rankBefore,
+            'materialsAwarded' => $outcome['materials'],
+            'materials' => $profile->materials(),
+            'lostShips' => $outcome['lost'],
+            'damagedShips' => $outcome['damaged'],
         ];
+    }
+
+    /**
+     * Długości statków gracza zatopionych w bitwie — liczone ze snapshotu gry:
+     * statek jest zatopiony, gdy wszystkie jego pola zostały trafione przez AI.
+     *
+     * @return list<int>
+     */
+    private function sunkPlayerShipLengths(Game $game): array
+    {
+        $hits = [];
+        foreach ($game->opponentShotsWithResults() as $shot) {
+            if (in_array($shot['result'], ['hit', 'sunk'], true)) {
+                $hits["{$shot['x']}:{$shot['y']}"] = true;
+            }
+        }
+
+        $lengths = [];
+        foreach ($game->fleet() ?? [] as $ship) {
+            $allHit = true;
+            foreach ($ship->cells() as $cell) {
+                if (!isset($hits["{$cell->x}:{$cell->y}"])) {
+                    $allHit = false;
+                    break;
+                }
+            }
+            if ($allHit) {
+                $lengths[] = $ship->length;
+            }
+        }
+
+        return $lengths;
     }
 }

--- a/src/Application/Expedition/StartIslandBattle.php
+++ b/src/Application/Expedition/StartIslandBattle.php
@@ -19,7 +19,9 @@ final class StartIslandBattle
 
     /**
      * Rozpoczyna bitwę o wyspę: waliduje rangę, tworzy grę wg zasad wyspy
-     * i rejestruje bitwę w profilu. Dalej działa zwykły flow gry (fleet/shots).
+     * (plansza z definicji wyspy, skład floty = sprawne statki kapitana —
+     * przeciwnik dostaje lustrzany skład) i rejestruje bitwę w profilu.
+     * Dalej działa zwykły flow gry (fleet/shots).
      */
     public function handle(string $profileId, string $islandId): Game
     {
@@ -37,8 +39,19 @@ final class StartIslandBattle
             throw new \DomainException(sprintf('Island locked: requires rank %s', $island->requiredRank->value));
         }
 
-        $game = $this->createGame->handle(null, null, $island->mode);
-        $profile->startBattle($island->id, $game->id());
+        $activeFleet = $profile->activeFleet();
+        if ([] === $activeFleet) {
+            throw new \DomainException('No seaworthy ships');
+        }
+
+        $composition = [];
+        foreach ($activeFleet as $ship) {
+            $length = $ship->type->length();
+            $composition[$length] = ($composition[$length] ?? 0) + 1;
+        }
+
+        $game = $this->createGame->handle($island->boardWidth, $island->boardHeight, $island->mode, $composition);
+        $profile->startBattle($island->id, $game->id(), array_map(static fn ($s) => $s->id, $activeFleet));
         $this->profiles->save($profile);
 
         return $game;

--- a/src/Domain/Expedition/CaptainProfile.php
+++ b/src/Domain/Expedition/CaptainProfile.php
@@ -6,14 +6,22 @@ use App\Domain\Shared\GameId;
 use App\Domain\Shared\ProfileId;
 
 /**
- * Profil kapitana: doświadczenie i rejestr bitew wypraw. Inwarianty:
- * XP nigdy nie maleje (doświadczenia się nie traci, także po porażce),
- * a każda bitwa jest rozliczana dokładnie raz.
+ * Profil kapitana: doświadczenie, flota (majątek) i rejestr bitew wypraw.
+ * Inwarianty: XP nigdy nie maleje (doświadczenia się nie traci, także po
+ * porażce), każda bitwa jest rozliczana dokładnie raz, a flota nigdy nie
+ * blokuje gry na zawsze — tratwa jest darmowa (bezpiecznik anty-softlock).
  */
 final class CaptainProfile
 {
-    /** @var array<string, array{island: string, settled: bool, result: ?string}> klucz: gameId */
+    private const STARTING_MATERIALS = 20;
+
+    /** @var array<string, array{island: string, settled: bool, result: ?string, ships?: list<string>}> klucz: gameId */
     private array $battles = [];
+
+    /** @var list<OwnedShip> */
+    private array $fleet = [];
+
+    private int $materials = 0;
 
     private function __construct(
         private ProfileId $id,
@@ -29,7 +37,27 @@ final class CaptainProfile
             throw new \InvalidArgumentException('Profile name must be 1-40 characters');
         }
 
-        return new self(ProfileId::new(), $name);
+        $self = new self(ProfileId::new(), $name);
+        $self->materials = self::STARTING_MATERIALS;
+        $self->fleet = self::startingFleet();
+
+        return $self;
+    }
+
+    /**
+     * Flota rozbitka: kuter + 3 tratwy — od pierwszej bitwy jest polowanie
+     * (plansza samych jednomasztowców to czysta loteria).
+     *
+     * @return list<OwnedShip>
+     */
+    private static function startingFleet(): array
+    {
+        return [
+            OwnedShip::build(ShipType::Kuter),
+            OwnedShip::build(ShipType::Tratwa),
+            OwnedShip::build(ShipType::Tratwa),
+            OwnedShip::build(ShipType::Tratwa),
+        ];
     }
 
     public function id(): ProfileId
@@ -52,15 +80,98 @@ final class CaptainProfile
         return Rank::fromXp($this->xp);
     }
 
-    /** Rejestruje rozpoczętą bitwę o wyspę (jedna gra = jedna bitwa). */
-    public function startBattle(string $islandId, GameId $gameId): void
+    // --- Flota i materiały ---
+
+    public function materials(): int
+    {
+        return $this->materials;
+    }
+
+    /** @return list<OwnedShip> */
+    public function fleet(): array
+    {
+        return $this->fleet;
+    }
+
+    /** @return list<OwnedShip> statki zdolne do bitwy (nieuszkodzone) */
+    public function activeFleet(): array
+    {
+        return array_values(array_filter($this->fleet, static fn (OwnedShip $s) => !$s->isDamaged()));
+    }
+
+    public function addMaterials(int $amount): void
+    {
+        if ($amount < 0) {
+            throw new \InvalidArgumentException('Negative materials amount');
+        }
+        $this->materials += $amount;
+    }
+
+    /** Buduje statek: bramka rangi + koszt w materiałach (stocznię sprawdza warstwa aplikacji). */
+    public function buildShip(ShipType $type): OwnedShip
+    {
+        if (!$this->rank()->atLeast($type->requiredRank())) {
+            throw new \DomainException(sprintf('Ship type locked: requires rank %s', $type->requiredRank()->value));
+        }
+        $this->spendMaterials($type->buildCost());
+
+        $ship = OwnedShip::build($type);
+        $this->fleet[] = $ship;
+
+        return $ship;
+    }
+
+    /** Remontuje uszkodzony statek za materiały. */
+    public function repairShip(string $shipId): OwnedShip
+    {
+        $ship = $this->shipById($shipId);
+        if (null === $ship) {
+            throw new \DomainException('Ship not found');
+        }
+        if (!$ship->isDamaged()) {
+            throw new \DomainException('Ship is not damaged');
+        }
+
+        $this->spendMaterials($ship->type->repairCost());
+        $ship->repair();
+
+        return $ship;
+    }
+
+    private function shipById(string $shipId): ?OwnedShip
+    {
+        foreach ($this->fleet as $ship) {
+            if ($ship->id === $shipId) {
+                return $ship;
+            }
+        }
+
+        return null;
+    }
+
+    private function spendMaterials(int $cost): void
+    {
+        if ($this->materials < $cost) {
+            throw new \DomainException('Not enough materials');
+        }
+        $this->materials -= $cost;
+    }
+
+    // --- Bitwy ---
+
+    /**
+     * Rejestruje rozpoczętą bitwę o wyspę (jedna gra = jedna bitwa).
+     *
+     * @param list<string> $shipIds statki, które wypłynęły (do rozliczenia strat)
+     */
+    public function startBattle(string $islandId, GameId $gameId, array $shipIds = []): void
     {
         $key = (string) $gameId;
         if (isset($this->battles[$key])) {
             throw new \DomainException('Battle already registered');
         }
 
-        $this->battles[$key] = ['island' => $islandId, 'settled' => false, 'result' => null];
+        $this->battles[$key] = ['island' => $islandId, 'settled' => false, 'result' => null, 'ships' => $shipIds];
     }
 
     /** Wyspa, o którą toczy się dana gra; null gdy gra nie należy do profilu. */
@@ -70,28 +181,79 @@ final class CaptainProfile
     }
 
     /**
-     * Rozlicza bitwę i przyznaje XP; zwraca przyznane XP (0 gdy już rozliczona —
-     * rozliczenie jest idempotentne).
+     * Rozlicza bitwę: XP i materiały nigdy nie giną (przyznawane też za porażkę),
+     * straty dotykają floty — zatopione statki po wygranej wymagają remontu,
+     * po przegranej są stracone. Idempotentne: druga próba zwraca zera.
+     *
+     * @param list<int> $sunkLengths długości statków gracza zatopionych w bitwie
+     *
+     * @return array{xp:int, materials:int, lost:list<string>, damaged:list<string>}
      */
-    public function settleBattle(GameId $gameId, string $result, int $xpAward): int
+    public function settleBattle(GameId $gameId, string $result, int $xpAward, int $materialsAward = 0, array $sunkLengths = []): array
     {
         if (!in_array($result, ['won', 'lost'], true)) {
             throw new \InvalidArgumentException('Result must be won|lost');
         }
-        if ($xpAward < 0) {
-            throw new \InvalidArgumentException('Negative XP award');
+        if ($xpAward < 0 || $materialsAward < 0) {
+            throw new \InvalidArgumentException('Negative battle award');
         }
 
         $key = (string) $gameId;
         $battle = $this->battles[$key] ?? throw new \DomainException('Battle not registered for this profile');
         if ($battle['settled']) {
-            return 0;
+            return ['xp' => 0, 'materials' => 0, 'lost' => [], 'damaged' => []];
         }
 
-        $this->battles[$key] = ['island' => $battle['island'], 'settled' => true, 'result' => $result];
-        $this->xp += $xpAward;
+        $battle['settled'] = true;
+        $battle['result'] = $result;
+        $this->battles[$key] = $battle;
 
-        return $xpAward;
+        $this->xp += $xpAward;
+        $this->materials += $materialsAward;
+
+        [$lost, $damaged] = $this->applyLosses($battle['ships'] ?? [], $result, $sunkLengths);
+
+        return ['xp' => $xpAward, 'materials' => $materialsAward, 'lost' => $lost, 'damaged' => $damaged];
+    }
+
+    /**
+     * Dobiera zatopione statki bitwy do egzemplarzy floty po długości
+     * (bitwa zna tylko długości) i aplikuje straty.
+     *
+     * @param list<string> $battleShipIds
+     * @param list<int>    $sunkLengths
+     *
+     * @return array{0: list<string>, 1: list<string>} [stracone typy, uszkodzone typy]
+     */
+    private function applyLosses(array $battleShipIds, string $result, array $sunkLengths): array
+    {
+        $lost = [];
+        $damaged = [];
+        $processed = [];
+
+        foreach ($sunkLengths as $length) {
+            foreach ($battleShipIds as $shipId) {
+                if (isset($processed[$shipId])) {
+                    continue;
+                }
+                $ship = $this->shipById($shipId);
+                if (null === $ship || $ship->type->length() !== $length || $ship->isDamaged()) {
+                    continue;
+                }
+
+                $processed[$shipId] = true;
+                if ('lost' === $result) {
+                    $this->fleet = array_values(array_filter($this->fleet, static fn (OwnedShip $s) => $s->id !== $shipId));
+                    $lost[] = $ship->type->value;
+                } else {
+                    $ship->markDamaged();
+                    $damaged[] = $ship->type->value;
+                }
+                break;
+            }
+        }
+
+        return [$lost, $damaged];
     }
 
     /** @return array{wins:int, losses:int} rozliczone bitwy o daną wyspę */
@@ -111,17 +273,23 @@ final class CaptainProfile
 
     // --- Snapshot (mapper persystencji) ---
 
-    /** @return array<string, array{island: string, settled: bool, result: ?string}> */
+    /** @return array<string, array{island: string, settled: bool, result: ?string, ships?: list<string>}> */
     public function battles(): array
     {
         return $this->battles;
     }
 
-    /** @param array<string, array{island: string, settled: bool, result: ?string}> $battles */
-    public static function fromSnapshot(ProfileId $id, string $name, int $xp, array $battles): self
+    /**
+     * @param array<string, array{island: string, settled: bool, result: ?string, ships?: list<string>}> $battles
+     * @param list<OwnedShip>|null                                                                       $fleet     null = profil sprzed ekonomii — dostaje flotę startową
+     * @param int|null                                                                                   $materials null = materiały startowe
+     */
+    public static function fromSnapshot(ProfileId $id, string $name, int $xp, array $battles, ?array $fleet = null, ?int $materials = null): self
     {
         $self = new self($id, $name, max(0, $xp));
         $self->battles = $battles;
+        $self->fleet = $fleet ?? self::startingFleet();
+        $self->materials = $materials ?? self::STARTING_MATERIALS;
 
         return $self;
     }

--- a/src/Domain/Expedition/Island.php
+++ b/src/Domain/Expedition/Island.php
@@ -4,7 +4,9 @@ namespace App\Domain\Expedition;
 
 /**
  * Definicja wyspy wyprawy: bitwa o zadanych zasadach, bramkowana rangą,
- * z nagrodą XP za wygraną i (mniejszą) za przegraną — z porażek też się uczymy.
+ * z nagrodami XP i materiałów za wygraną i (mniejszymi) za przegraną —
+ * z porażek też się uczymy. Stocznia na wyspie buduje i remontuje flotę;
+ * jej poziom ogranicza dostępne typy statków.
  */
 final class Island
 {
@@ -16,12 +18,23 @@ final class Island
         public readonly string $mode, // 'classic' | 'fun' — wariant zasad bitwy
         public readonly int $xpWin,
         public readonly int $xpLoss,
+        public readonly int $materialsWin,
+        public readonly int $materialsLoss,
+        public readonly int $shipyardLevel,
+        public readonly int $boardWidth,
+        public readonly int $boardHeight,
     ) {
         if (!in_array($mode, ['classic', 'fun'], true)) {
             throw new \InvalidArgumentException('Island mode must be classic|fun');
         }
         if ($xpWin < 0 || $xpLoss < 0 || $xpLoss > $xpWin) {
             throw new \InvalidArgumentException('Invalid island XP rewards');
+        }
+        if ($materialsWin < 0 || $materialsLoss < 0 || $materialsLoss > $materialsWin) {
+            throw new \InvalidArgumentException('Invalid island material rewards');
+        }
+        if ($shipyardLevel < 0 || $boardWidth < 5 || $boardHeight < 5) {
+            throw new \InvalidArgumentException('Invalid island parameters');
         }
     }
 

--- a/src/Domain/Expedition/OwnedShip.php
+++ b/src/Domain/Expedition/OwnedShip.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Egzemplarz statku we flocie kapitana. Uszkodzony statek nie wypływa
+ * do bitwy — wymaga remontu w stoczni (za materiały).
+ */
+final class OwnedShip
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly ShipType $type,
+        private bool $damaged = false,
+    ) {
+    }
+
+    public static function build(ShipType $type): self
+    {
+        return new self(Uuid::v4()->toRfc4122(), $type);
+    }
+
+    public function isDamaged(): bool
+    {
+        return $this->damaged;
+    }
+
+    public function markDamaged(): void
+    {
+        $this->damaged = true;
+    }
+
+    public function repair(): void
+    {
+        $this->damaged = false;
+    }
+}

--- a/src/Domain/Expedition/ShipType.php
+++ b/src/Domain/Expedition/ShipType.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Domain\Expedition;
+
+/**
+ * Typ statku floty wyprawy. Długość wiąże typ z bitwą (agregat Game zna tylko
+ * długości), a koszty i bramki (ranga, poziom stoczni) napędzają ekonomię.
+ * Tratwa jest zawsze darmowa — bezpiecznik anty-softlock: rozbitek zawsze
+ * może wypłynąć (docs/GAME_DESIGN.md, filar 5).
+ */
+enum ShipType: string
+{
+    case Tratwa = 'tratwa';
+    case Kuter = 'kuter';
+    case Niszczyciel = 'niszczyciel';
+    case Lotniskowiec = 'lotniskowiec';
+
+    /** Długość statku na planszy bitwy. */
+    public function length(): int
+    {
+        return match ($this) {
+            self::Tratwa => 1,
+            self::Kuter => 2,
+            self::Niszczyciel => 3,
+            self::Lotniskowiec => 4,
+        };
+    }
+
+    /** Koszt budowy w materiałach. */
+    public function buildCost(): int
+    {
+        return match ($this) {
+            self::Tratwa => 0,
+            self::Kuter => 20,
+            self::Niszczyciel => 50,
+            self::Lotniskowiec => 120,
+        };
+    }
+
+    /** Koszt remontu uszkodzonego statku w materiałach. */
+    public function repairCost(): int
+    {
+        return match ($this) {
+            self::Tratwa => 0,
+            self::Kuter => 8,
+            self::Niszczyciel => 20,
+            self::Lotniskowiec => 45,
+        };
+    }
+
+    /** Minimalna ranga kapitana pozwalająca budować ten typ. */
+    public function requiredRank(): Rank
+    {
+        return match ($this) {
+            self::Tratwa, self::Kuter => Rank::Rozbitek,
+            self::Niszczyciel => Rank::Marynarz,
+            self::Lotniskowiec => Rank::Kapitan,
+        };
+    }
+
+    /** Minimalny poziom stoczni potrzebny do budowy i remontu. */
+    public function requiredShipyardLevel(): int
+    {
+        return match ($this) {
+            self::Tratwa, self::Kuter => 1,
+            self::Niszczyciel => 2,
+            self::Lotniskowiec => 3,
+        };
+    }
+}

--- a/src/Domain/Expedition/StaticIslandCatalog.php
+++ b/src/Domain/Expedition/StaticIslandCatalog.php
@@ -3,7 +3,8 @@
 namespace App\Domain\Expedition;
 
 /**
- * Stały katalog wysp plastra A: liniowa trasa 6 wysp, kolejne bramkowane rangą.
+ * Stały katalog wysp plastra A/B: liniowa trasa 6 wysp, kolejne bramkowane
+ * rangą; wczesne wyspy mają mniejsze plansze (krótsze polowanie małą flotą).
  * Docelowo (plaster C) katalog będzie generowany z seeda świata.
  */
 final class StaticIslandCatalog implements IslandCatalog
@@ -22,6 +23,11 @@ final class StaticIslandCatalog implements IslandCatalog
                 mode: 'classic',
                 xpWin: 40,
                 xpLoss: 10,
+                materialsWin: 20,
+                materialsLoss: 5,
+                shipyardLevel: 1,
+                boardWidth: 7,
+                boardHeight: 7,
             ),
             new Island(
                 id: 'mielizny',
@@ -31,6 +37,11 @@ final class StaticIslandCatalog implements IslandCatalog
                 mode: 'classic',
                 xpWin: 50,
                 xpLoss: 12,
+                materialsWin: 25,
+                materialsLoss: 6,
+                shipyardLevel: 1,
+                boardWidth: 8,
+                boardHeight: 8,
             ),
             new Island(
                 id: 'wyspa-sygnalowa',
@@ -40,6 +51,11 @@ final class StaticIslandCatalog implements IslandCatalog
                 mode: 'fun',
                 xpWin: 70,
                 xpLoss: 15,
+                materialsWin: 35,
+                materialsLoss: 8,
+                shipyardLevel: 2,
+                boardWidth: 9,
+                boardHeight: 9,
             ),
             new Island(
                 id: 'archipelag-mgiel',
@@ -49,6 +65,11 @@ final class StaticIslandCatalog implements IslandCatalog
                 mode: 'fun',
                 xpWin: 80,
                 xpLoss: 20,
+                materialsWin: 40,
+                materialsLoss: 10,
+                shipyardLevel: 2,
+                boardWidth: 10,
+                boardHeight: 10,
             ),
             new Island(
                 id: 'ciesnina-sztormow',
@@ -58,6 +79,11 @@ final class StaticIslandCatalog implements IslandCatalog
                 mode: 'fun',
                 xpWin: 100,
                 xpLoss: 25,
+                materialsWin: 50,
+                materialsLoss: 12,
+                shipyardLevel: 3,
+                boardWidth: 10,
+                boardHeight: 10,
             ),
             new Island(
                 id: 'twierdza-admiralicji',
@@ -67,6 +93,11 @@ final class StaticIslandCatalog implements IslandCatalog
                 mode: 'fun',
                 xpWin: 120,
                 xpLoss: 30,
+                materialsWin: 60,
+                materialsLoss: 15,
+                shipyardLevel: 3,
+                boardWidth: 10,
+                boardHeight: 10,
             ),
         ];
     }

--- a/src/Infrastructure/Http/Controller/ExpeditionController.php
+++ b/src/Infrastructure/Http/Controller/ExpeditionController.php
@@ -2,10 +2,14 @@
 
 namespace App\Infrastructure\Http\Controller;
 
+use App\Application\Expedition\BuildShip;
 use App\Application\Expedition\CreateProfile;
 use App\Application\Expedition\GetExpedition;
+use App\Application\Expedition\RepairShip;
 use App\Application\Expedition\SettleBattle;
 use App\Application\Expedition\StartIslandBattle;
+use App\Domain\Expedition\OwnedShip;
+use App\Domain\Expedition\ShipType;
 use App\Infrastructure\Http\Error\ApiException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,6 +24,8 @@ final class ExpeditionController
         private GetExpedition $getExpedition,
         private StartIslandBattle $startIslandBattle,
         private SettleBattle $settleBattle,
+        private BuildShip $buildShip,
+        private RepairShip $repairShip,
     ) {
     }
 
@@ -80,6 +86,61 @@ final class ExpeditionController
         $this->assertUuid($gameId, 'game');
 
         return new JsonResponse($this->settleBattle->handle($id, $gameId));
+    }
+
+    #[Route('/{id}/ships', name: 'api_profiles_build_ship', methods: ['POST'])]
+    public function buildShip(string $id, Request $request): JsonResponse
+    {
+        $this->assertUuid($id, 'profile');
+        $payload = $this->jsonPayload($request);
+
+        $type = ShipType::tryFrom((string) ($payload['type'] ?? ''));
+        $islandId = $payload['islandId'] ?? null;
+        if (null === $type || !is_string($islandId)) {
+            throw new ApiException('Missing or invalid fields: type:ship-type, islandId:string', 'VALIDATION_ERROR', 400);
+        }
+
+        $ship = $this->buildShip->handle($id, $islandId, $type);
+
+        return new JsonResponse($this->shipView($ship), 201);
+    }
+
+    #[Route('/{id}/ships/{shipId}/repair', name: 'api_profiles_repair_ship', methods: ['POST'])]
+    public function repairShip(string $id, string $shipId, Request $request): JsonResponse
+    {
+        $this->assertUuid($id, 'profile');
+        $payload = $this->jsonPayload($request);
+
+        $islandId = $payload['islandId'] ?? null;
+        if (!is_string($islandId)) {
+            throw new ApiException('Missing or invalid field: islandId:string', 'VALIDATION_ERROR', 400);
+        }
+
+        $ship = $this->repairShip->handle($id, $islandId, $shipId);
+
+        return new JsonResponse($this->shipView($ship));
+    }
+
+    /** @return array<string,mixed> */
+    private function shipView(OwnedShip $ship): array
+    {
+        return [
+            'id' => $ship->id,
+            'type' => $ship->type->value,
+            'length' => $ship->type->length(),
+            'damaged' => $ship->isDamaged(),
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function jsonPayload(Request $request): array
+    {
+        $payload = json_decode($request->getContent() ?: '{}', true);
+        if (!is_array($payload)) {
+            throw new ApiException('Invalid JSON', 'VALIDATION_ERROR', 400);
+        }
+
+        return $payload;
     }
 
     private function assertUuid(string $id, string $what): void

--- a/src/Infrastructure/Http/Error/ExceptionSubscriber.php
+++ b/src/Infrastructure/Http/Error/ExceptionSubscriber.php
@@ -89,9 +89,12 @@ final class ExceptionSubscriber implements EventSubscriberInterface
             return ['TORPEDO_LAUNCH_INVALID', 422];
         }
 
-        // Wyprawa: wyspa zamknięta rangą (komunikat niesie wymaganą rangę)
+        // Wyprawa: bramki rangowe (komunikaty niosą wymaganą rangę)
         if (str_starts_with($message, 'Island locked')) {
             return ['ISLAND_LOCKED', 403];
+        }
+        if (str_starts_with($message, 'Ship type locked')) {
+            return ['SHIP_TYPE_LOCKED', 403];
         }
 
         return match ($message) {
@@ -105,6 +108,11 @@ final class ExceptionSubscriber implements EventSubscriberInterface
             'Island not found' => ['ISLAND_NOT_FOUND', 404],
             'Battle not registered for this profile' => ['BATTLE_NOT_REGISTERED', 404],
             'Battle not finished yet' => ['BATTLE_NOT_FINISHED', 409],
+            'Not enough materials' => ['NOT_ENOUGH_MATERIALS', 409],
+            'Shipyard level too low for this ship type' => ['SHIPYARD_TOO_LOW', 409],
+            'Ship not found' => ['SHIP_NOT_FOUND', 404],
+            'Ship is not damaged' => ['SHIP_NOT_DAMAGED', 409],
+            'No seaworthy ships' => ['NO_SEAWORTHY_SHIPS', 409],
             default => ['VALIDATION_ERROR', 400],
         };
     }

--- a/src/Infrastructure/Persistence/Doctrine/Mapper/ProfileSnapshotMapper.php
+++ b/src/Infrastructure/Persistence/Doctrine/Mapper/ProfileSnapshotMapper.php
@@ -3,17 +3,25 @@
 namespace App\Infrastructure\Persistence\Doctrine\Mapper;
 
 use App\Domain\Expedition\CaptainProfile;
+use App\Domain\Expedition\OwnedShip;
+use App\Domain\Expedition\ShipType;
 use App\Domain\Shared\ProfileId;
 
 final class ProfileSnapshotMapper
 {
-    /** @return array{name: string, xp: int, battles: array<string, array{island:string, settled:bool, result:?string}>} */
+    /** @return array<string,mixed> */
     public function toArray(CaptainProfile $profile): array
     {
         return [
             'name' => $profile->name(),
             'xp' => $profile->xp(),
             'battles' => $profile->battles(),
+            'materials' => $profile->materials(),
+            'fleet' => array_map(static fn (OwnedShip $ship) => [
+                'id' => $ship->id,
+                'type' => $ship->type->value,
+                'damaged' => $ship->isDamaged(),
+            ], $profile->fleet()),
         ];
     }
 
@@ -25,11 +33,28 @@ final class ProfileSnapshotMapper
             if (!is_array($battle) || !isset($battle['island'])) {
                 continue;
             }
-            $battles[(string) $gameId] = [
+            $entry = [
                 'island' => (string) $battle['island'],
                 'settled' => (bool) ($battle['settled'] ?? false),
                 'result' => isset($battle['result']) ? (string) $battle['result'] : null,
             ];
+            if (isset($battle['ships']) && is_array($battle['ships'])) {
+                $entry['ships'] = array_values(array_map('strval', $battle['ships']));
+            }
+            $battles[(string) $gameId] = $entry;
+        }
+
+        // Flota: brak klucza = profil sprzed ekonomii (CaptainProfile da flotę startową)
+        $fleet = null;
+        if (isset($state['fleet']) && is_array($state['fleet'])) {
+            $fleet = [];
+            foreach ($state['fleet'] as $ship) {
+                $type = is_array($ship) ? ShipType::tryFrom((string) ($ship['type'] ?? '')) : null;
+                if (null === $type || !isset($ship['id'])) {
+                    continue;
+                }
+                $fleet[] = new OwnedShip((string) $ship['id'], $type, (bool) ($ship['damaged'] ?? false));
+            }
         }
 
         return CaptainProfile::fromSnapshot(
@@ -37,6 +62,8 @@ final class ProfileSnapshotMapper
             (string) ($state['name'] ?? 'Rozbitek'),
             (int) ($state['xp'] ?? 0),
             $battles,
+            $fleet,
+            isset($state['materials']) ? max(0, (int) $state['materials']) : null,
         );
     }
 }

--- a/tests/Functional/ExpeditionApiTest.php
+++ b/tests/Functional/ExpeditionApiTest.php
@@ -7,7 +7,6 @@ namespace Tests\Functional;
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Tests\Support\FleetFactory;
 
 final class ExpeditionApiTest extends WebTestCase
 {
@@ -20,75 +19,92 @@ final class ExpeditionApiTest extends WebTestCase
     {
         $client = static::createClient();
 
-        // 1) profil kapitana
+        // 1) profil kapitana z flotą startową (kuter + 3 tratwy) i materiałami
         $profile = $this->post($client, '/api/profiles', ['name' => 'Jacek']);
         self::assertResponseStatusCodeSame(201);
         self::assertSame('rozbitek', $profile['rank']);
-        self::assertSame(0, $profile['xp']);
         $profileId = $profile['id'];
 
-        // 2) stan wyprawy: pierwsza wyspa otwarta, ostatnia zamknięta
-        $client->request('GET', "/api/profiles/$profileId/expedition");
-        self::assertResponseIsSuccessful();
-        $expedition = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        // 2) stan wyprawy: pierwsza wyspa otwarta, ostatnia zamknięta; flota i stocznie widoczne
+        $expedition = $this->getExpedition($client, $profileId);
 
         $islands = $expedition['islands'];
         self::assertSame('zatoka-rozbitka', $islands[0]['id']);
         self::assertTrue($islands[0]['unlocked']);
         self::assertFalse(end($islands)['unlocked']);
         self::assertSame(['rank' => 'marynarz', 'xpNeeded' => 80], $expedition['profile']['nextRank']);
+        self::assertSame(20, $expedition['profile']['materials']);
+        self::assertCount(4, $expedition['fleet']);
+        self::assertSame(1, $islands[0]['shipyardLevel']);
+        self::assertNotEmpty($expedition['shipTypes']);
 
         // 3) zamknięta wyspa → 403 ISLAND_LOCKED
         $lockedId = end($islands)['id'];
         $this->post($client, "/api/profiles/$profileId/islands/$lockedId/battle");
         self::assertResponseStatusCodeSame(403);
 
-        // 4) bitwa o pierwszą wyspę (classic)
+        // 4) bitwa o pierwszą wyspę: plansza 7×7, skład = sprawna flota gracza
         $battle = $this->post($client, "/api/profiles/$profileId/islands/zatoka-rozbitka/battle");
         self::assertResponseStatusCodeSame(201);
         self::assertSame('classic', $battle['ruleset']);
+        self::assertSame(['w' => 7, 'h' => 7], $battle['board']);
         $gameId = $battle['id'];
+
+        $client->request('GET', "/api/games/$gameId");
+        $view = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['2' => 1, '1' => 3], $view['allowedShips']);
 
         // 5) rozliczenie przed końcem bitwy → 409
         $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
         self::assertResponseStatusCodeSame(409);
 
-        // 6) wystaw flotę i zatop całą flotę przeciwnika (deterministyczna w env test)
-        $fleet = FleetFactory::classic10x10Array();
-        $this->post($client, "/api/games/$gameId/fleet", ['ships' => $fleet]);
+        // 6) wystaw flotę (kuter + 3 tratwy) i zatop lustrzaną flotę przeciwnika:
+        //    deterministyczny generator pakuje wierszowo → znane pozycje
+        $this->post($client, "/api/games/$gameId/fleet", ['ships' => [
+            ['x' => 0, 'y' => 0, 'o' => 'h', 'l' => 2],
+            ['x' => 4, 'y' => 0, 'o' => 'h', 'l' => 1],
+            ['x' => 6, 'y' => 2, 'o' => 'h', 'l' => 1],
+            ['x' => 0, 'y' => 4, 'o' => 'h', 'l' => 1],
+        ]]);
         self::assertResponseIsSuccessful();
 
-        foreach ($fleet as $s) {
-            $horiz = 'h' === strtolower((string) $s['o']);
-            for ($i = 0; $i < $s['l']; ++$i) {
-                $this->post($client, "/api/games/$gameId/shots", [
-                    'x' => $s['x'] + ($horiz ? $i : 0),
-                    'y' => $s['y'] + ($horiz ? 0 : $i),
-                ]);
-                self::assertResponseIsSuccessful();
-            }
+        foreach ([[0, 0], [1, 0], [3, 0], [5, 0], [0, 2]] as [$x, $y]) {
+            $this->post($client, "/api/games/$gameId/shots", ['x' => $x, 'y' => $y]);
+            self::assertResponseIsSuccessful();
         }
 
-        // 7) rozliczenie: XP za wygraną wg wyspy
+        // 7) rozliczenie: XP + materiały wg wyspy; wygrana nie odbiera statków na stałe
         $settled = $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
         self::assertResponseIsSuccessful();
         self::assertSame('won', $settled['result']);
         self::assertSame(40, $settled['awarded']);
-        self::assertSame(40, $settled['xp']);
-        self::assertSame('rozbitek', $settled['rank']);
-        self::assertFalse($settled['rankUp']);
+        self::assertSame(20, $settled['materialsAwarded']);
+        self::assertSame(40, $settled['materials']);
+        self::assertSame([], $settled['lostShips']);
 
-        // 8) idempotencja: drugie rozliczenie bez XP
+        // 8) idempotencja: drugie rozliczenie bez nagród
         $again = $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
         self::assertResponseIsSuccessful();
         self::assertSame(0, $again['awarded']);
-        self::assertSame(40, $again['xp']);
+        self::assertSame(0, $again['materialsAwarded']);
 
-        // 9) statystyki wyspy w stanie wyprawy
-        $client->request('GET', "/api/profiles/$profileId/expedition");
-        $expedition = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        // 9) stocznia: budowa kutra za 20 materiałów
+        $ship = $this->post($client, "/api/profiles/$profileId/ships", [
+            'type' => 'kuter', 'islandId' => 'zatoka-rozbitka',
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('kuter', $ship['type']);
+
+        $expedition = $this->getExpedition($client, $profileId);
+        self::assertSame(20, $expedition['profile']['materials']);
+        self::assertCount(5, $expedition['fleet']);
         self::assertSame(1, $expedition['islands'][0]['wins']);
-        self::assertSame(40, $expedition['profile']['xp']);
+
+        // 10) niszczyciel w stoczni poziomu 1 → 409 SHIPYARD_TOO_LOW
+        $this->post($client, "/api/profiles/$profileId/ships", [
+            'type' => 'niszczyciel', 'islandId' => 'zatoka-rozbitka',
+        ]);
+        self::assertResponseStatusCodeSame(409);
     }
 
     public function testSettleRejectsForeignGame(): void
@@ -102,6 +118,15 @@ final class ExpeditionApiTest extends WebTestCase
 
         $this->post($client, "/api/profiles/$profileId/battles/$gameId/settle");
         self::assertResponseStatusCodeSame(404);
+    }
+
+    /** @return array<string,mixed> */
+    private function getExpedition(KernelBrowser $client, string $profileId): array
+    {
+        $client->request('GET', "/api/profiles/$profileId/expedition");
+        self::assertResponseIsSuccessful();
+
+        return json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
     }
 
     /** @return array<string,mixed> */

--- a/tests/Unit/CaptainProfileTest.php
+++ b/tests/Unit/CaptainProfileTest.php
@@ -6,6 +6,8 @@ use App\Domain\Expedition\CaptainProfile;
 use App\Domain\Expedition\Rank;
 use App\Domain\Shared\GameId;
 
+const NO_AWARDS = ['xp' => 0, 'materials' => 0, 'lost' => [], 'damaged' => []];
+
 it('startuje jako rozbitek z zerowym XP', function () {
     $profile = CaptainProfile::create('Jacek');
 
@@ -17,33 +19,39 @@ it('odrzuca pustą i za długą nazwę', function (string $name) {
     CaptainProfile::create($name);
 })->with(['', '   ', str_repeat('x', 41)])->throws(InvalidArgumentException::class);
 
-it('rozlicza wygraną bitwę i nalicza XP', function () {
+it('rozlicza wygraną bitwę i nalicza XP oraz materiały', function () {
     $profile = CaptainProfile::create('Jacek');
     $gameId = GameId::new();
     $profile->startBattle('zatoka-rozbitka', $gameId);
 
-    expect($profile->settleBattle($gameId, 'won', 40))->toBe(40)
+    $outcome = $profile->settleBattle($gameId, 'won', 40, 20);
+
+    expect($outcome['xp'])->toBe(40)
+        ->and($outcome['materials'])->toBe(20)
         ->and($profile->xp())->toBe(40)
         ->and($profile->battleStats('zatoka-rozbitka'))->toBe(['wins' => 1, 'losses' => 0]);
 });
 
-it('nalicza XP także za przegraną — doświadczenia się nie traci', function () {
+it('nalicza XP i materiały także za przegraną — doświadczenia się nie traci', function () {
     $profile = CaptainProfile::create('Jacek');
     $gameId = GameId::new();
     $profile->startBattle('mielizny', $gameId);
 
-    expect($profile->settleBattle($gameId, 'lost', 12))->toBe(12)
+    $outcome = $profile->settleBattle($gameId, 'lost', 12, 6);
+
+    expect($outcome['xp'])->toBe(12)
         ->and($profile->xp())->toBe(12)
+        ->and($profile->materials())->toBe(26) // 20 startowych + 6
         ->and($profile->battleStats('mielizny'))->toBe(['wins' => 0, 'losses' => 1]);
 });
 
-it('rozliczenie jest idempotentne — druga próba nie daje XP', function () {
+it('rozliczenie jest idempotentne — druga próba nie daje nagród', function () {
     $profile = CaptainProfile::create('Jacek');
     $gameId = GameId::new();
     $profile->startBattle('zatoka-rozbitka', $gameId);
-    $profile->settleBattle($gameId, 'won', 40);
+    $profile->settleBattle($gameId, 'won', 40, 20);
 
-    expect($profile->settleBattle($gameId, 'won', 40))->toBe(0)
+    expect($profile->settleBattle($gameId, 'won', 40, 20))->toBe(NO_AWARDS)
         ->and($profile->xp())->toBe(40);
 });
 
@@ -75,11 +83,19 @@ it('round-tripuje przez snapshot', function () {
     $profile = CaptainProfile::create('Jacek');
     $gameId = GameId::new();
     $profile->startBattle('zatoka-rozbitka', $gameId);
-    $profile->settleBattle($gameId, 'won', 40);
+    $profile->settleBattle($gameId, 'won', 40, 20);
 
-    $restored = CaptainProfile::fromSnapshot($profile->id(), $profile->name(), $profile->xp(), $profile->battles());
+    $restored = CaptainProfile::fromSnapshot(
+        $profile->id(),
+        $profile->name(),
+        $profile->xp(),
+        $profile->battles(),
+        $profile->fleet(),
+        $profile->materials(),
+    );
 
     expect($restored->xp())->toBe(40)
+        ->and($restored->materials())->toBe(40) // 20 startowych + 20 z bitwy
         ->and($restored->battleStats('zatoka-rozbitka'))->toBe(['wins' => 1, 'losses' => 0])
-        ->and($restored->settleBattle($gameId, 'won', 40))->toBe(0);
+        ->and($restored->settleBattle($gameId, 'won', 40, 20))->toBe(NO_AWARDS);
 });

--- a/tests/Unit/FleetPropertyTest.php
+++ b/tests/Unit/FleetPropertyTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Expedition\CaptainProfile;
+use App\Domain\Expedition\ShipType;
+use App\Domain\Shared\GameId;
+
+it('nowy profil dostaje flotę startową: kuter + 3 tratwy i 20 materiałów', function () {
+    $profile = CaptainProfile::create('Jacek');
+
+    $types = array_map(static fn ($s) => $s->type, $profile->fleet());
+
+    expect($profile->materials())->toBe(20)
+        ->and($types)->toBe([ShipType::Kuter, ShipType::Tratwa, ShipType::Tratwa, ShipType::Tratwa])
+        ->and($profile->activeFleet())->toHaveCount(4);
+});
+
+it('tratwa jest zawsze darmowa — bezpiecznik anty-softlock', function () {
+    $profile = CaptainProfile::create('Jacek');
+
+    $ship = $profile->buildShip(ShipType::Tratwa);
+
+    expect($profile->materials())->toBe(20)
+        ->and($ship->type)->toBe(ShipType::Tratwa)
+        ->and($profile->fleet())->toHaveCount(5);
+});
+
+it('budowa kutra kosztuje materiały', function () {
+    $profile = CaptainProfile::create('Jacek');
+
+    $profile->buildShip(ShipType::Kuter);
+
+    expect($profile->materials())->toBe(0);
+});
+
+it('odrzuca budowę bez materiałów', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $profile->buildShip(ShipType::Kuter); // materiały: 20 → 0
+    $profile->buildShip(ShipType::Kuter);
+})->throws(DomainException::class, 'Not enough materials');
+
+it('odrzuca budowę typu ponad rangę kapitana', function () {
+    CaptainProfile::create('Jacek')->buildShip(ShipType::Niszczyciel);
+})->throws(DomainException::class, 'Ship type locked: requires rank marynarz');
+
+it('wygrana bitwa: zatopione statki wymagają remontu, nie giną', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $shipIds = array_map(static fn ($s) => $s->id, $profile->activeFleet());
+    $profile->startBattle('zatoka-rozbitka', $gameId, $shipIds);
+
+    // AI zatopiło kuter (długość 2) i jedną tratwę (długość 1)
+    $outcome = $profile->settleBattle($gameId, 'won', 40, 20, [2, 1]);
+
+    expect($outcome['damaged'])->toBe(['kuter', 'tratwa'])
+        ->and($outcome['lost'])->toBe([])
+        ->and($profile->fleet())->toHaveCount(4)
+        ->and($profile->activeFleet())->toHaveCount(2);
+});
+
+it('przegrana bitwa: zatopione statki są stracone', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $shipIds = array_map(static fn ($s) => $s->id, $profile->activeFleet());
+    $profile->startBattle('zatoka-rozbitka', $gameId, $shipIds);
+
+    // przegrana = cała wysłana flota zatopiona
+    $outcome = $profile->settleBattle($gameId, 'lost', 10, 5, [2, 1, 1, 1]);
+
+    expect($outcome['lost'])->toBe(['kuter', 'tratwa', 'tratwa', 'tratwa'])
+        ->and($profile->fleet())->toHaveCount(0)
+        // ale rozbitek zawsze może odbudować się darmową tratwą
+        ->and($profile->buildShip(ShipType::Tratwa)->type)->toBe(ShipType::Tratwa);
+});
+
+it('remont przywraca statek do służby za materiały', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $gameId = GameId::new();
+    $kuter = $profile->activeFleet()[0];
+    $profile->startBattle('zatoka-rozbitka', $gameId, [$kuter->id]);
+    $profile->settleBattle($gameId, 'won', 40, 20, [2]);
+
+    expect($kuter->isDamaged())->toBeTrue();
+
+    $profile->repairShip($kuter->id);
+
+    expect($kuter->isDamaged())->toBeFalse()
+        ->and($profile->materials())->toBe(32); // 20 + 20 - 8 (remont kutra)
+});
+
+it('odrzuca remont sprawnego statku', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $profile->repairShip($profile->fleet()[0]->id);
+})->throws(DomainException::class, 'Ship is not damaged');
+
+it('profil sprzed ekonomii dostaje flotę startową przy odczycie snapshotu', function () {
+    $profile = CaptainProfile::create('Jacek');
+    $restored = CaptainProfile::fromSnapshot($profile->id(), 'Jacek', 100, []);
+
+    expect($restored->fleet())->toHaveCount(4)
+        ->and($restored->materials())->toBe(20);
+});
+
+it('bramki typów statków rosną spójnie z progresją', function () {
+    foreach (ShipType::cases() as $type) {
+        expect($type->repairCost())->toBeLessThanOrEqual($type->buildCost())
+            ->and($type->length())->toBeGreaterThanOrEqual(1);
+    }
+    // lotniskowiec = szczyt progresji: najdroższy, najdłuższy, największa stocznia
+    expect(ShipType::Lotniskowiec->requiredShipyardLevel())->toBe(3)
+        ->and(ShipType::Tratwa->buildCost())->toBe(0);
+});


### PR DESCRIPTION
Część #32 (Epic B, krok 2/3) — flota przestaje być abstrakcją bitwy i staje się majątkiem kapitana: buduje się ją w stoczniach za materiały, a bitwy zostawiają ślady.

## Co

**Domena (`Expedition`):**
- `ShipType`: tratwa(1)/kuter(2)/niszczyciel(3)/lotniskowiec(4) — koszt budowy (0/20/50/120) i remontu (0/8/20/45), bramka rangi (niszczyciel=marynarz, lotniskowiec=kapitan) i poziomu stoczni (1/1/2/3). **Tratwa zawsze darmowa** — bezpiecznik anty-softlock z GAME_DESIGN
- `OwnedShip`: egzemplarz we flocie (id, typ, uszkodzony); `CaptainProfile` trzyma flotę i materiały; flota startowa rozbitka = kuter + 3 tratwy + 20 materiałów (plansza samych tratw to loteria — od pierwszej bitwy jest polowanie)
- Rozliczenie bitwy: **zatopione statki po wygranej wymagają remontu, po przegranej są stracone**; XP i materiały nigdy nie giną (nagrody także za porażkę). Dobór egzemplarzy do strat po długości (bitwa zna tylko długości)
- Wyspy: poziom stoczni (1/1/2/2/3/3), nagrody materiałowe (20/25/35/40/50/60 za wygraną), rozmiar planszy (7×7 → 10×10 — krótsze polowanie małą flotą na starcie)

**Aplikacja/API:**
- `StartIslandBattle`: skład bitwy = sprawna flota kapitana (tu wpina się parametr składu z #38), przeciwnik lustrzany, plansza z wyspy; uszkodzone statki nie płyną
- `SettleBattle`: straty liczone ze snapshotu gry (pola trafione przez AI vs flota gracza) — nic od klienta; odpowiedź + `materialsAwarded/materials/lostShips/damagedShips`
- Nowe endpointy: `POST /api/profiles/{id}/ships` (budowa), `POST /api/profiles/{id}/ships/{shipId}/repair`; expedition zwraca flotę, materiały i katalog typów (dane pod UI stoczni)
- Kompatybilność: profil sprzed ekonomii dostaje flotę startową przy odczycie snapshotu; bez migracji (JSON)

## Testy

- Unit: `FleetPropertyTest` (11 — flota startowa, darmowa tratwa, koszty, bramka rangi, straty won/lost, remont, odbudowa po utracie wszystkiego, legacy snapshot), zaktualizowany `CaptainProfileTest` (nagrody materiałowe, nowy kontrakt settle)
- Funkcjonalny `ExpeditionApiTest`: pełna pętla na nowej ekonomii — bitwa 7×7 składem kuter+3 tratwy (`allowedShips` z gry), wygrana → +40 XP +20 materiałów → budowa kutra → odmowa niszczyciela w stoczni poziomu 1 (409)
- `make test-unit` 89 ✓, `make test-func` 22 ✓, `make test-int` 2 ✓, PHPStan/cs-fixer czyste

Krok 3 (osobny PR): broń wynika ze składu floty — nalot=lotniskowiec, torpeda=niszczyciel, sonar=kuter; zatopienie nośnika odbiera broń. Potem UI portu/stoczni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)