### PR TITLE
Derive weapons from fleet composition, add port UI

### DIFF
--- a/frontend/src/api/expeditionApi.ts
+++ b/frontend/src/api/expeditionApi.ts
@@ -10,6 +10,22 @@ export const RANK_LABELS: Record<RankName, string> = {
     admiral: 'Admirał',
 };
 
+export type ShipTypeName = 'tratwa' | 'kuter' | 'niszczyciel' | 'lotniskowiec';
+
+export const SHIP_LABELS: Record<ShipTypeName, string> = {
+    tratwa: 'Tratwa',
+    kuter: 'Kuter',
+    niszczyciel: 'Niszczyciel',
+    lotniskowiec: 'Lotniskowiec',
+};
+
+export const SHIP_ICONS: Record<ShipTypeName, string> = {
+    tratwa: '🛶',
+    kuter: '🚤',
+    niszczyciel: '🚢',
+    lotniskowiec: '🛳️',
+};
+
 export interface ProfileDTO {
     id: string;
     name: string;
@@ -19,6 +35,24 @@ export interface ProfileDTO {
 
 export interface ExpeditionProfileDTO extends ProfileDTO {
     nextRank: { rank: RankName; xpNeeded: number } | null;
+    materials: number;
+}
+
+export interface FleetShipDTO {
+    id: string;
+    type: ShipTypeName;
+    length: number;
+    damaged: boolean;
+    repairCost: number;
+}
+
+export interface ShipTypeDTO {
+    type: ShipTypeName;
+    length: number;
+    buildCost: number;
+    repairCost: number;
+    requiredRank: RankName;
+    requiredShipyardLevel: number;
 }
 
 export interface IslandDTO {
@@ -29,6 +63,10 @@ export interface IslandDTO {
     requiredRank: RankName;
     xpWin: number;
     xpLoss: number;
+    materialsWin: number;
+    materialsLoss: number;
+    shipyardLevel: number;
+    board: { w: number; h: number };
     unlocked: boolean;
     wins: number;
     losses: number;
@@ -36,6 +74,8 @@ export interface IslandDTO {
 
 export interface ExpeditionDTO {
     profile: ExpeditionProfileDTO;
+    fleet: FleetShipDTO[];
+    shipTypes: ShipTypeDTO[];
     islands: IslandDTO[];
 }
 
@@ -45,6 +85,10 @@ export interface SettleResultDTO {
     xp: number;
     rank: RankName;
     rankUp: boolean;
+    materialsAwarded: number;
+    materials: number;
+    lostShips: ShipTypeName[];
+    damagedShips: ShipTypeName[];
 }
 
 export async function createProfile(name: string): Promise<ProfileDTO> {
@@ -61,4 +105,12 @@ export async function startIslandBattle(profileId: string, islandId: string): Pr
 
 export async function settleBattle(profileId: string, gameId: string): Promise<SettleResultDTO> {
     return http.post<SettleResultDTO>(`/profiles/${profileId}/battles/${gameId}/settle`, {});
+}
+
+export async function buildShip(profileId: string, islandId: string, type: ShipTypeName): Promise<FleetShipDTO> {
+    return http.post<FleetShipDTO>(`/profiles/${profileId}/ships`, { type, islandId });
+}
+
+export async function repairShip(profileId: string, islandId: string, shipId: string): Promise<FleetShipDTO> {
+    return http.post<FleetShipDTO>(`/profiles/${profileId}/ships/${shipId}/repair`, { islandId });
 }

--- a/frontend/src/components/Game.vue
+++ b/frontend/src/components/Game.vue
@@ -10,7 +10,7 @@ import { clearCurrentBattle, getCurrentBattle } from '../lib/expeditionSession'
 // automatycznie (zagnieżdżone w zwykłym obiekcie NIE są odpakowywane).
 const {
     status, finished, turn, loading, error, disabled, attack, width, height,
-    ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
+    ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells, aliveShipLengths,
     noteMarks, toggleNote,
     shotsCount, hitsCount, missesCount, duplicatesCount, opponentHitsCount,
     toast, toastType,
@@ -160,7 +160,7 @@ watch([diagonalAvailable, torpedoDirection], () => {
 
 const weaponHint = computed(() => {
     switch (weaponMode.value) {
-        case 'torpedo': return 'Kliknij WŁASNY niezatopiony statek (podświetlony na Twojej planszy) — torpeda popłynie z jego pozycji w wybranym kierunku.';
+        case 'torpedo': return 'Kliknij WŁASNY niezatopiony niszczyciel (3-masztowiec, podświetlony na Twojej planszy) — torpeda popłynie z jego pozycji w wybranym kierunku.';
         case 'sonar': return 'Kliknij centrum skanu — sonar sprawdzi krzyż o promieniu 3.';
         case 'airraid': return 'Kliknij centrum nalotu — ostrzał obszaru 3×3.';
         default: return '';
@@ -197,10 +197,16 @@ watch(gameOver, async (over) => {
         Koniec gry: {{ status === 'won' ? 'Wygrana' : 'Przegrana' }}
         <template v-if="expeditionResult">
             <span class="xp-award">
-                +{{ expeditionResult.awarded }} XP
+                +{{ expeditionResult.awarded }} XP · +{{ expeditionResult.materialsAwarded }} 🔩
                 <template v-if="expeditionResult.rankUp">
                     ⚓ awans: {{ RANK_LABELS[expeditionResult.rank] }}!
                 </template>
+            </span>
+            <span v-if="expeditionResult.lostShips.length" class="fleet-toll">
+                ⚓ stracone: {{ expeditionResult.lostShips.join(', ') }}
+            </span>
+            <span v-else-if="expeditionResult.damagedShips.length" class="fleet-toll">
+                🔧 do remontu: {{ expeditionResult.damagedShips.join(', ') }}
             </span>
             <router-link class="btn small" :to="{ name: 'expedition' }">Wróć na wyprawę</router-link>
         </template>
@@ -231,18 +237,22 @@ watch(gameOver, async (over) => {
                 <button class="wbtn" :class="{ active: weaponMode === 'shot' }" @click="selectWeapon('shot')">
                     🎯 Strzał
                 </button>
+                <!-- broń wynika ze składu floty: zatopiony nośnik ją odbiera -->
                 <button class="wbtn" :class="{ active: weaponMode === 'torpedo' }"
-                        :disabled="weapons.torpedo.used >= weapons.torpedo.limit"
+                        :disabled="weapons.torpedo.used >= weapons.torpedo.limit || !aliveShipLengths.has(3)"
+                        :title="!aliveShipLengths.has(3) ? 'Niszczyciel zatopiony — torpedy niedostępne' : ''"
                         @click="selectWeapon('torpedo')">
                     🚀 Torpeda {{ weapons.torpedo.limit - weapons.torpedo.used }}/{{ weapons.torpedo.limit }}
                 </button>
                 <button class="wbtn" :class="{ active: weaponMode === 'sonar' }"
-                        :disabled="weapons.sonar.used >= weapons.sonar.limit"
+                        :disabled="weapons.sonar.used >= weapons.sonar.limit || !aliveShipLengths.has(2)"
+                        :title="!aliveShipLengths.has(2) ? 'Kuter zwiadowczy zatopiony — sonar niedostępny' : ''"
                         @click="selectWeapon('sonar')">
                     📡 Sonar {{ weapons.sonar.limit - weapons.sonar.used }}/{{ weapons.sonar.limit }}
                 </button>
                 <button class="wbtn" :class="{ active: weaponMode === 'airraid' }"
-                        :disabled="weapons.airRaid.used >= weapons.airRaid.limit"
+                        :disabled="weapons.airRaid.used >= weapons.airRaid.limit || !aliveShipLengths.has(4)"
+                        :title="!aliveShipLengths.has(4) ? 'Lotniskowiec zatopiony — naloty niedostępne' : ''"
                         @click="selectWeapon('airraid')">
                     ✈️ Nalot {{ weapons.airRaid.limit - weapons.airRaid.used }}/{{ weapons.airRaid.limit }}
                 </button>
@@ -310,6 +320,7 @@ watch(gameOver, async (over) => {
 .game-banner.won { background: #e6ffe6; border-color: #b3ffb3; color: #0a5b0a; }
 .game-banner.lost { background: #ffe6e6; border-color: #ffb3b3; color: #7a0a0a; }
 .game-banner .xp-award { font-weight: 700; margin: 0 0.5rem; }
+.game-banner .fleet-toll { margin: 0 0.5rem; font-size: 0.9rem; }
 .game-banner a.btn { text-decoration: none; display: inline-block; }
 .btn.small { margin-left: .75rem; padding: .25rem .5rem; font-size: .9rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
 .boards { display: flex; gap: 20px; align-items: start; }

--- a/frontend/src/composables/useGame.ts
+++ b/frontend/src/composables/useGame.ts
@@ -125,14 +125,31 @@ export function useGame() {
         playerFleet.value = dto.playerFleet ?? [];
     }
 
+    /** Długości własnych statków, które wciąż pływają (żywe nośniki broni). */
+    const aliveShipLengths = computed<Set<number>>(() => {
+        const alive = new Set<number>();
+        const ov = playerUnderFireOverlay.value;
+        for (const s of playerFleet.value) {
+            let sunk = true;
+            for (let i = 0; i < s.l; i++) {
+                const x = s.x + ((s.o as string).toLowerCase() === 'h' ? i : 0);
+                const y = s.y + ((s.o as string).toLowerCase() === 'v' ? i : 0);
+                if (ov[y]?.[x] !== 'opp-hit') sunk = false;
+            }
+            if (!sunk) alive.add(s.l);
+        }
+        return alive;
+    });
+
     /**
-     * Komórki własnych NIEZATOPIONYCH statków — legalne wyrzutnie torped
-     * (reguła domenowa: torpeda startuje z żywego statku gracza).
+     * Komórki własnych NIEZATOPIONYCH NISZCZYCIELI (3-masztowców) — legalne
+     * wyrzutnie torped (reguła domenowa: broń wynika ze składu floty).
      */
     const launchableCells = computed<Set<string>>(() => {
         const set = new Set<string>();
         const ov = playerUnderFireOverlay.value;
         for (const s of playerFleet.value) {
+            if (s.l !== 3) continue;
             const cells: Array<[number, number]> = [];
             let sunk = true;
             for (let i = 0; i < s.l; i++) {
@@ -351,7 +368,7 @@ export function useGame() {
         gameId, size, width, height, playerGrid, playerUnderFireOverlay, enemyFogGrid, turn, status, finished,
         loading, error, start, refresh, shot, attack, disabled,
         // tryb fun
-        ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells,
+        ruleset, weapons, opponentWeapons, weaponMode, torpedoDirection, sonarMarks, launchableCells, aliveShipLengths,
         // notatki (saper-style)
         noteMarks, toggleNote,
         // stats

--- a/frontend/src/views/Expedition.vue
+++ b/frontend/src/views/Expedition.vue
@@ -36,6 +36,7 @@
                 </div>
                 <div class="xp-row">
                     <span>{{ expedition.profile.xp }} XP</span>
+                    <span class="materials">🔩 {{ expedition.profile.materials }}</span>
                     <template v-if="expedition.profile.nextRank">
                         <div class="xp-bar" role="progressbar">
                             <div class="xp-fill" :style="{ width: xpProgress + '%' }"></div>
@@ -47,6 +48,45 @@
                     </template>
                     <span v-else class="muted">najwyższa ranga — morza należą do Ciebie</span>
                 </div>
+            </section>
+
+            <!-- Flota i port -->
+            <section class="card port">
+                <h2>⚓ Flota</h2>
+                <ul class="ships">
+                    <li v-for="ship in expedition.fleet" :key="ship.id" class="ship" :class="{ dmg: ship.damaged }">
+                        <span class="ship-name">{{ SHIP_ICONS[ship.type] }} {{ SHIP_LABELS[ship.type] }}</span>
+                        <template v-if="ship.damaged">
+                            <span class="status">🔧 uszkodzony</span>
+                            <button
+                                class="btn small"
+                                :disabled="busy || repairBlock(ship) !== null"
+                                :title="repairBlock(ship) ?? ''"
+                                @click="onRepair(ship)"
+                            >
+                                Remont ({{ ship.repairCost }} 🔩)
+                            </button>
+                            <span v-if="repairBlock(ship)" class="muted">{{ repairBlock(ship) }}</span>
+                        </template>
+                        <span v-else class="status ok">sprawny</span>
+                    </li>
+                </ul>
+
+                <h3>🏗️ Stocznia <span class="muted">(najlepsza dostępna: poziom {{ bestShipyardLevel }})</span></h3>
+                <ul class="ships">
+                    <li v-for="t in expedition.shipTypes" :key="t.type" class="ship">
+                        <span class="ship-name">{{ SHIP_ICONS[t.type] }} {{ SHIP_LABELS[t.type] }} ({{ t.length }}-masztowiec)</span>
+                        <button
+                            class="btn small"
+                            :disabled="busy || buildBlock(t) !== null"
+                            :title="buildBlock(t) ?? ''"
+                            @click="onBuild(t)"
+                        >
+                            Buduj ({{ t.buildCost }} 🔩)
+                        </button>
+                        <span v-if="buildBlock(t)" class="muted">{{ buildBlock(t) }}</span>
+                    </li>
+                </ul>
             </section>
 
             <!-- Trwająca bitwa -->
@@ -71,8 +111,9 @@
                     </div>
                     <p class="desc">{{ island.description }}</p>
                     <div class="island-meta">
-                        <span>🏆 +{{ island.xpWin }} XP</span>
-                        <span class="muted">porażka: +{{ island.xpLoss }} XP</span>
+                        <span>🏆 +{{ island.xpWin }} XP, +{{ island.materialsWin }} 🔩</span>
+                        <span class="muted">porażka: +{{ island.xpLoss }} XP, +{{ island.materialsLoss }} 🔩</span>
+                        <span class="muted">🏗️ stocznia poz. {{ island.shipyardLevel }} · plansza {{ island.board.w }}×{{ island.board.h }}</span>
                         <span v-if="island.wins || island.losses" class="muted">
                             bilans: {{ island.wins }}W / {{ island.losses }}P
                         </span>
@@ -96,8 +137,9 @@
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import {
-    createProfile, getExpedition, settleBattle, startIslandBattle,
-    RANK_LABELS, type ExpeditionDTO, type IslandDTO, type RankName,
+    buildShip, createProfile, getExpedition, repairShip, settleBattle, startIslandBattle,
+    RANK_LABELS, SHIP_ICONS, SHIP_LABELS,
+    type ExpeditionDTO, type FleetShipDTO, type IslandDTO, type RankName, type ShipTypeDTO,
 } from '../api/expeditionApi';
 import { ApiError } from '../api/http';
 import {
@@ -125,6 +167,78 @@ const xpProgress = computed(() => {
 
 function rankLabel(rank: RankName): string {
     return RANK_LABELS[rank] ?? rank;
+}
+
+// --- Port: budowa i remont w najlepszej dostępnej stoczni ---
+
+const busy = ref(false);
+
+const RANK_ORDER: RankName[] = ['rozbitek', 'marynarz', 'kapitan', 'admiral'];
+
+function rankAtLeast(rank: RankName, required: RankName): boolean {
+    return RANK_ORDER.indexOf(rank) >= RANK_ORDER.indexOf(required);
+}
+
+/** Odblokowana wyspa ze stocznią o wymaganym poziomie (do budowy/remontu). */
+function shipyardIslandFor(level: number): IslandDTO | null {
+    return expedition.value?.islands.find(i => i.unlocked && i.shipyardLevel >= level) ?? null;
+}
+
+const bestShipyardLevel = computed(() =>
+    Math.max(0, ...(expedition.value?.islands.filter(i => i.unlocked).map(i => i.shipyardLevel) ?? [0]))
+);
+
+/** Powód blokady budowy typu; null = można budować. */
+function buildBlock(t: ShipTypeDTO): string | null {
+    const profile = expedition.value?.profile;
+    if (!profile) return 'wczytywanie…';
+    if (!rankAtLeast(profile.rank, t.requiredRank)) return `wymaga rangi: ${rankLabel(t.requiredRank)}`;
+    if (!shipyardIslandFor(t.requiredShipyardLevel)) return `wymaga stoczni poziomu ${t.requiredShipyardLevel}`;
+    if (profile.materials < t.buildCost) return 'za mało materiałów';
+    return null;
+}
+
+/** Powód blokady remontu statku; null = można remontować. */
+function repairBlock(ship: FleetShipDTO): string | null {
+    const profile = expedition.value?.profile;
+    const type = expedition.value?.shipTypes.find(t => t.type === ship.type);
+    if (!profile || !type) return 'wczytywanie…';
+    if (!shipyardIslandFor(type.requiredShipyardLevel)) return `wymaga stoczni poziomu ${type.requiredShipyardLevel}`;
+    if (profile.materials < ship.repairCost) return 'za mało materiałów';
+    return null;
+}
+
+async function onBuild(t: ShipTypeDTO) {
+    const profileId = getProfileId();
+    const island = shipyardIslandFor(t.requiredShipyardLevel);
+    if (!profileId || !island) return;
+    busy.value = true;
+    error.value = '';
+    try {
+        await buildShip(profileId, island.id, t.type);
+        expedition.value = await getExpedition(profileId);
+    } catch (e: any) {
+        error.value = e?.message ?? 'Budowa nie powiodła się';
+    } finally {
+        busy.value = false;
+    }
+}
+
+async function onRepair(ship: FleetShipDTO) {
+    const profileId = getProfileId();
+    const type = expedition.value?.shipTypes.find(t => t.type === ship.type);
+    const island = shipyardIslandFor(type?.requiredShipyardLevel ?? 1);
+    if (!profileId || !island) return;
+    busy.value = true;
+    error.value = '';
+    try {
+        await repairShip(profileId, island.id, ship.id);
+        expedition.value = await getExpedition(profileId);
+    } catch (e: any) {
+        error.value = e?.message ?? 'Remont nie powiódł się';
+    } finally {
+        busy.value = false;
+    }
 }
 
 onMounted(load);
@@ -221,6 +335,16 @@ h1 { margin-bottom: 0.75rem; }
 .xp-bar { flex: 1 1 140px; min-width: 120px; height: 8px; background: #e2e8f0; border-radius: 4px; overflow: hidden; }
 .xp-fill { height: 100%; background: #1f6feb; transition: width 0.4s ease; }
 .pending { display: flex; gap: 0.75rem; align-items: center; background: #fff7ed; border-color: #fed7aa; }
+.materials { font-weight: 600; color: #92400e; }
+.port h2, .port h3 { margin: 0 0 0.4rem; font-size: 1.05rem; }
+.port h3 { margin-top: 0.8rem; }
+.ships { list-style: none; padding: 0; margin: 0; }
+.ship { display: flex; gap: 0.6rem; align-items: center; padding: 0.25rem 0; flex-wrap: wrap; }
+.ship.dmg .ship-name { opacity: 0.7; }
+.ship-name { min-width: 12rem; }
+.status { font-size: 0.85rem; color: #92400e; }
+.status.ok { color: #15803d; }
+.btn.small { padding: 0.25rem 0.6rem; font-size: 0.85rem; }
 .islands { list-style: none; padding: 0; margin: 0; }
 .island.locked { opacity: 0.6; background: #f8fafc; }
 .island-head { display: flex; justify-content: space-between; align-items: baseline; gap: 0.6rem; }

--- a/src/Application/Game/OpponentTurn.php
+++ b/src/Application/Game/OpponentTurn.php
@@ -79,8 +79,10 @@ final class OpponentTurn
         $huntMode = [] === ($game->aiState()['targets'] ?? []);
         $weapons = 'fun' === $game->ruleset()->name() ? $game->opponentWeaponsState() : [];
 
-        // 1) Zwiad: sonar w trybie hunt (nie zużywa akcji ofensywnej)
-        if ($huntMode && $this->hasUses($weapons, 'sonar') && $this->decide(self::SONAR_CHANCE)) {
+        // 1) Zwiad: sonar w trybie hunt (nie zużywa akcji ofensywnej);
+        //    broń wymaga żywego nośnika (kutra) we flocie AI
+        if ($huntMode && $this->hasUses($weapons, 'sonar')
+            && $game->opponentHasWeaponCarrier(Game::SONAR_CARRIER_LENGTH) && $this->decide(self::SONAR_CHANCE)) {
             $center = $this->bestSonarCenter($view, $game->ruleset()->weapons()->sonar->radius);
             if (null !== $center) {
                 $detected = [];
@@ -108,7 +110,8 @@ final class OpponentTurn
             }
         }
 
-        if ($huntMode && $this->hasUses($weapons, 'airRaid') && $this->decide(self::AIR_RAID_CHANCE)) {
+        if ($huntMode && $this->hasUses($weapons, 'airRaid')
+            && $game->opponentHasWeaponCarrier(Game::AIR_RAID_CARRIER_LENGTH) && $this->decide(self::AIR_RAID_CHANCE)) {
             [$halfX, $halfY] = $this->airRaidHalfExtents($game);
             $center = $this->bestAirRaidCenter($view, $halfX, $halfY);
             if (null !== $center) {

--- a/src/Domain/Game/BoardSide.php
+++ b/src/Domain/Game/BoardSide.php
@@ -116,12 +116,36 @@ final class BoardSide
         return null !== $ship && !$this->isSunk($ship);
     }
 
+    /** Czy na polu stoi niezatopiony statek o zadanej długości (nośnik broni). */
+    public function hasUnsunkShipOfLengthAt(int $x, int $y, int $length): bool
+    {
+        $ship = $this->shipAtKey($x.':'.$y);
+
+        return null !== $ship && $ship->length === $length && !$this->isSunk($ship);
+    }
+
+    /** Czy strona ma jeszcze niezatopiony statek o zadanej długości. */
+    public function hasUnsunkShipOfLength(int $length): bool
+    {
+        if (!$this->hasFleet()) {
+            return false;
+        }
+        foreach ($this->board->ships() as $ship) {
+            if ($ship->length === $length && !$this->isSunk($ship)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
-     * Komórki wszystkich niezatopionych statków tej strony (legalne wyrzutnie torped).
+     * Komórki niezatopionych statków tej strony; $length zawęża do statków
+     * o danej długości (legalne wyrzutnie torped = niszczyciele).
      *
      * @return list<array{x:int,y:int}>
      */
-    public function unsunkShipCells(): array
+    public function unsunkShipCells(?int $length = null): array
     {
         if (!$this->hasFleet()) {
             return [];
@@ -129,7 +153,7 @@ final class BoardSide
 
         $out = [];
         foreach ($this->board->ships() as $ship) {
-            if ($this->isSunk($ship)) {
+            if ($this->isSunk($ship) || (null !== $length && $ship->length !== $length)) {
                 continue;
             }
             foreach ($ship->cells() as $c) {

--- a/src/Domain/Game/FunRuleset.php
+++ b/src/Domain/Game/FunRuleset.php
@@ -32,12 +32,23 @@ final class FunRuleset implements Ruleset
         return $this->ships ?? FleetComposition::CLASSIC;
     }
 
+    /**
+     * Broń wynika ze składu floty: jedno użycie na statek-nośnik
+     * (torpeda=niszczyciel, sonar=kuter, nalot=lotniskowiec; patrz stałe
+     * Game::*_CARRIER_LENGTH). Dla floty klasycznej daje to dokładnie
+     * dotychczasowe limity: torpeda 2, sonar 3, nalot 1.
+     */
     public function weapons(): WeaponSpecs
     {
+        $ships = $this->allowedShips();
+        $torpedoes = $ships[Game::TORPEDO_CARRIER_LENGTH] ?? 0;
+        $sonars = $ships[Game::SONAR_CARRIER_LENGTH] ?? 0;
+        $airRaids = $ships[Game::AIR_RAID_CARRIER_LENGTH] ?? 0;
+
         return new WeaponSpecs(
-            torpedo: new TorpedoSpec(uses: 2, diagonalUses: 1),
-            sonar: new SonarSpec(uses: 3, radius: 3),
-            airRaid: new AirRaidSpec(uses: 1, maxArea: new Area(3, 3)),
+            torpedo: new TorpedoSpec(uses: $torpedoes, diagonalUses: min(1, $torpedoes)),
+            sonar: new SonarSpec(uses: $sonars, radius: 3),
+            airRaid: new AirRaidSpec(uses: $airRaids, maxArea: new Area(3, 3)),
         );
     }
 }

--- a/src/Domain/Game/Game.php
+++ b/src/Domain/Game/Game.php
@@ -6,6 +6,15 @@ use App\Domain\Shared\GameId;
 
 final class Game
 {
+    /**
+     * Broń wynika ze składu floty: długości statków-nośników. Zatopienie
+     * nośnika odbiera broń do końca bitwy (mapowanie na typy floty wyprawy:
+     * kuter=2, niszczyciel=3, lotniskowiec=4 — bitwa zna tylko długości).
+     */
+    public const SONAR_CARRIER_LENGTH = 2;
+    public const TORPEDO_CARRIER_LENGTH = 3;
+    public const AIR_RAID_CARRIER_LENGTH = 4;
+
     private GameStatus $status = GameStatus::Pending;
 
     /** Strona gracza: jego flota + strzały przeciwnika (AI) w nią oddane. */
@@ -425,8 +434,8 @@ final class Game
             throw new \DomainException('Torpedo start outside board');
         }
 
-        if (!$this->playerSide->hasUnsunkShipAt($start->x, $start->y)) {
-            throw new \DomainException('Torpedo must be launched from an unsunk ship');
+        if (!$this->playerSide->hasUnsunkShipOfLengthAt($start->x, $start->y, self::TORPEDO_CARRIER_LENGTH)) {
+            throw new \DomainException('Torpedo must be launched from an unsunk destroyer');
         }
 
         $this->consumeTorpedo('player', $direction);
@@ -463,6 +472,7 @@ final class Game
         }
 
         $radius = $this->resolveSonarRadius('player', $radius);
+        $this->assertWeaponCarrierAfloat($this->playerSide, self::SONAR_CARRIER_LENGTH, 'Sonar requires an unsunk scout ship');
         $this->consumeWeapon('player', 'sonar');
 
         $target = $this->targetSide();
@@ -518,6 +528,7 @@ final class Game
         }
 
         $this->assertWeaponAvailable('player', 'airRaid');
+        $this->assertWeaponCarrierAfloat($this->playerSide, self::AIR_RAID_CARRIER_LENGTH, 'Air raid requires an unsunk carrier');
 
         $max = $this->ruleset->weapons()->airRaid->maxArea;
         if (2 * $area->width + 1 > $max->width || 2 * $area->height + 1 > $max->height) {
@@ -546,13 +557,27 @@ final class Game
     // --- Bronie specjalne przeciwnika (AI) — lustrzane wobec broni gracza ---
 
     /**
-     * Komórki niezatopionych statków AI — legalne wyrzutnie jego torped.
+     * Komórki niezatopionych niszczycieli AI — legalne wyrzutnie jego torped.
      *
      * @return list<array{x:int,y:int}>
      */
     public function opponentLaunchableCells(): array
     {
-        return $this->opponentSide->unsunkShipCells();
+        return $this->opponentSide->unsunkShipCells(self::TORPEDO_CARRIER_LENGTH);
+    }
+
+    /** Czy AI ma jeszcze niezatopiony nośnik broni o danej długości. */
+    public function opponentHasWeaponCarrier(int $length): bool
+    {
+        return $this->opponentSide->hasUnsunkShipOfLength($length);
+    }
+
+    /** Rzuca, gdy nośnik broni danej strony został zatopiony. */
+    private function assertWeaponCarrierAfloat(BoardSide $side, int $length, string $message): void
+    {
+        if (!$side->hasUnsunkShipOfLength($length)) {
+            throw new \DomainException($message);
+        }
     }
 
     /**
@@ -577,8 +602,8 @@ final class Game
             throw new \DomainException('Torpedo start outside board');
         }
 
-        if (!$this->opponentSide->hasUnsunkShipAt($start->x, $start->y)) {
-            throw new \DomainException('Torpedo must be launched from an unsunk ship');
+        if (!$this->opponentSide->hasUnsunkShipOfLengthAt($start->x, $start->y, self::TORPEDO_CARRIER_LENGTH)) {
+            throw new \DomainException('Torpedo must be launched from an unsunk destroyer');
         }
 
         $this->consumeTorpedo('opponent', $direction);
@@ -611,6 +636,7 @@ final class Game
         }
 
         $radius = $this->resolveSonarRadius('opponent', $radius);
+        $this->assertWeaponCarrierAfloat($this->opponentSide, self::SONAR_CARRIER_LENGTH, 'Sonar requires an unsunk scout ship');
         $this->consumeWeapon('opponent', 'sonar');
 
         $w = $this->ruleset->boardSize()->width;
@@ -657,6 +683,7 @@ final class Game
         }
 
         $this->assertWeaponAvailable('opponent', 'airRaid');
+        $this->assertWeaponCarrierAfloat($this->opponentSide, self::AIR_RAID_CARRIER_LENGTH, 'Air raid requires an unsunk carrier');
 
         $max = $this->ruleset->weapons()->airRaid->maxArea;
         if (2 * $area->width + 1 > $max->width || 2 * $area->height + 1 > $max->height) {

--- a/src/Infrastructure/Http/Error/ExceptionSubscriber.php
+++ b/src/Infrastructure/Http/Error/ExceptionSubscriber.php
@@ -85,8 +85,12 @@ final class ExceptionSubscriber implements EventSubscriberInterface
         if (str_ends_with($message, 'limit reached')) {
             return ['WEAPON_LIMIT_REACHED', 422];
         }
-        if ('Torpedo must be launched from an unsunk ship' === $message) {
+        if (str_starts_with($message, 'Torpedo must be launched')) {
             return ['TORPEDO_LAUNCH_INVALID', 422];
+        }
+        // Zatopiony nośnik broni (kuter/niszczyciel/lotniskowiec)
+        if ('Sonar requires an unsunk scout ship' === $message || 'Air raid requires an unsunk carrier' === $message) {
+            return ['WEAPON_CARRIER_SUNK', 422];
         }
 
         // Wyprawa: bramki rangowe (komunikaty niosą wymaganą rangę)

--- a/tests/Functional/GameApiFunModeTest.php
+++ b/tests/Functional/GameApiFunModeTest.php
@@ -37,7 +37,7 @@ final class GameApiFunModeTest extends WebTestCase
         self::assertSame(['used' => 0, 'limit' => 1], $view['weapons']['airRaid']);
 
         // torpedo: full turn — results + AI response + turn back to player
-        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 0, 'direction' => 'E']));
+        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 2, 'direction' => 'E']));
         self::assertResponseIsSuccessful();
         $torpedo = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
         self::assertCount(10, $torpedo['results']);
@@ -85,7 +85,7 @@ final class GameApiFunModeTest extends WebTestCase
         self::assertResponseIsSuccessful();
 
         // classic → torpeda niedostępna (422 z ExceptionSubscriber)
-        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 0, 'direction' => 'E']));
+        $client->request('POST', "/api/games/$id/torpedo", server: ['CONTENT_TYPE' => 'application/json'], content: json_encode(['x' => 0, 'y' => 2, 'direction' => 'E']));
         self::assertResponseStatusCodeSame(422);
 
         // classic → sonar niedostępny

--- a/tests/Unit/GameFireTorpedoTest.php
+++ b/tests/Unit/GameFireTorpedoTest.php
@@ -11,6 +11,11 @@ use App\Domain\Game\Game;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FleetFactory;
 
+/**
+ * Torpeda startuje wyłącznie z niezatopionego NISZCZYCIELA (3-masztowca).
+ * W klasycznym układzie floty niszczyciele stoją na (0,2)-(2,2) [H]
+ * i (6,0)-(6,2) [V].
+ */
 final class GameFireTorpedoTest extends TestCase
 {
     public function testFireTorpedoAcrossEntireRow(): void
@@ -20,40 +25,40 @@ final class GameFireTorpedoTest extends TestCase
         $fleet = FleetFactory::classic10x10();
         $game->placeFleet($fleet);
 
-        // Torpeda od (0,0) na wschód przez cały wiersz
-        $results = $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+        // Torpeda z niszczyciela (0,2) na wschód przez cały wiersz
+        $results = $game->fireTorpedo(new Coordinate(0, 2), Direction::E);
 
         $this->assertCount(10, $results);
         foreach ($results as $i => $r) {
             $this->assertSame($i, $r['x']);
-            $this->assertSame(0, $r['y']);
+            $this->assertSame(2, $r['y']);
             $this->assertContains($r['result'], ['hit', 'sunk', 'miss', 'duplicate']);
         }
 
         // Ponowne odpalenie w ten sam wiersz — wszystkie duplicate.
-        // Start z (6,0): w tym teście (fallback bez floty przeciwnika) pierwsza
-        // torpeda zatopiła własnego 4-masztowca na (0,0), a wyrzutnią może być
-        // tylko niezatopiony statek; trójmasztowiec (6,0)-(6,2) wciąż pływa.
-        $resultsDup = $game->fireTorpedo(new Coordinate(6, 0), Direction::E);
+        // Start z (6,2): pierwsza torpeda (fallback bez floty przeciwnika)
+        // zatopiła własnego niszczyciela na (0,2) i trafiła (6,2), ale pionowy
+        // niszczyciel (6,0)-(6,2) wciąż pływa — wyrzutnia legalna.
+        $resultsDup = $game->fireTorpedo(new Coordinate(6, 2), Direction::E);
         foreach ($resultsDup as $r) {
             $this->assertSame('duplicate', $r['result']);
         }
     }
 
-    public function testFireTorpedoNorthFromCenter(): void
+    public function testFireTorpedoSouthAlongColumn(): void
     {
         $rules = new FunRuleset();
         $game = Game::create($rules);
         $fleet = FleetFactory::classic10x10();
         $game->placeFleet($fleet);
 
-        // Z (5, 9) w górę — 10 pól (y: 9..0)
-        $results = $game->fireTorpedo(new Coordinate(5, 9), Direction::N);
+        // Z niszczyciela (6,0) w dół — 10 pól (y: 0..9)
+        $results = $game->fireTorpedo(new Coordinate(6, 0), Direction::S);
 
         $this->assertCount(10, $results);
         foreach ($results as $i => $r) {
-            $this->assertSame(5, $r['x']);
-            $this->assertSame(9 - $i, $r['y']);
+            $this->assertSame(6, $r['x']);
+            $this->assertSame($i, $r['y']);
             $this->assertContains($r['result'], ['hit', 'sunk', 'miss', 'duplicate']);
         }
     }
@@ -64,22 +69,35 @@ final class GameFireTorpedoTest extends TestCase
         $game->placeFleet(FleetFactory::classic10x10());
 
         $this->expectException(\DomainException::class);
-        $this->expectExceptionMessage('Torpedo must be launched from an unsunk ship');
-        // (1,1) to woda — 4-masztowiec stoi w wierszu 0, trójmasztowiec w wierszu 2
+        $this->expectExceptionMessage('Torpedo must be launched from an unsunk destroyer');
+        // (1,1) to woda
         $game->fireTorpedo(new Coordinate(1, 1), Direction::E);
     }
 
-    public function testTorpedoCannotBeLaunchedFromSunkShip(): void
+    public function testTorpedoCannotBeLaunchedFromNonDestroyer(): void
     {
         $game = Game::create(new FunRuleset());
         $game->placeFleet(FleetFactory::classic10x10());
 
-        // przeciwnik zatapia jedynkę gracza na (0,6)
-        $game->fireOpponentShot(new Coordinate(0, 6));
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Torpedo must be launched from an unsunk destroyer');
+        // (0,0) to 4-masztowiec (lotniskowiec) — nośnik nalotów, nie torped
+        $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+    }
+
+    public function testTorpedoCannotBeLaunchedFromSunkDestroyer(): void
+    {
+        $game = Game::create(new FunRuleset());
+        $game->placeFleet(FleetFactory::classic10x10());
+
+        // przeciwnik zatapia pionowego niszczyciela gracza (6,0)-(6,2)
+        $game->fireOpponentShot(new Coordinate(6, 0));
+        $game->fireOpponentShot(new Coordinate(6, 1));
+        $game->fireOpponentShot(new Coordinate(6, 2));
 
         $this->expectException(\DomainException::class);
-        $this->expectExceptionMessage('Torpedo must be launched from an unsunk ship');
-        $game->fireTorpedo(new Coordinate(0, 6), Direction::E);
+        $this->expectExceptionMessage('Torpedo must be launched from an unsunk destroyer');
+        $game->fireTorpedo(new Coordinate(6, 0), Direction::E);
     }
 
     public function testTorpedoCanBeLaunchedFromDamagedButUnsunkShip(): void
@@ -87,10 +105,10 @@ final class GameFireTorpedoTest extends TestCase
         $game = Game::create(new FunRuleset());
         $game->placeFleet(FleetFactory::classic10x10());
 
-        // przeciwnik trafia 4-masztowiec gracza na (0,0) — uszkodzony, ale pływa
-        $game->fireOpponentShot(new Coordinate(0, 0));
+        // przeciwnik trafia niszczyciela gracza na (0,2) — uszkodzony, ale pływa
+        $game->fireOpponentShot(new Coordinate(0, 2));
 
-        $results = $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+        $results = $game->fireTorpedo(new Coordinate(0, 2), Direction::E);
         $this->assertCount(10, $results);
     }
 
@@ -99,13 +117,13 @@ final class GameFireTorpedoTest extends TestCase
         $game = Game::create(new FunRuleset());
         $game->placeFleet(FleetFactory::classic10x10());
 
-        // z 4-masztowca (0,0) po przekątnej SE — komórki (i,i)
-        $results = $game->fireTorpedo(new Coordinate(0, 0), Direction::SE);
+        // z niszczyciela (0,2) po przekątnej SE — komórki (i, i+2)
+        $results = $game->fireTorpedo(new Coordinate(0, 2), Direction::SE);
 
-        $this->assertCount(10, $results);
+        $this->assertCount(8, $results);
         foreach ($results as $i => $r) {
             $this->assertSame($i, $r['x']);
-            $this->assertSame($i, $r['y']);
+            $this->assertSame($i + 2, $r['y']);
         }
         $this->assertSame(1, $game->weaponsState()['torpedoDiagonal']['used']);
     }
@@ -114,21 +132,21 @@ final class GameFireTorpedoTest extends TestCase
     {
         $game = Game::create(new FunRuleset());
         $game->placeFleet(FleetFactory::classic10x10());
-        $game->fireTorpedo(new Coordinate(0, 0), Direction::SE);
+        $game->fireTorpedo(new Coordinate(0, 2), Direction::SE);
 
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessage('Diagonal torpedo limit reached');
-        $game->fireTorpedo(new Coordinate(0, 2), Direction::NE);
+        $game->fireTorpedo(new Coordinate(6, 0), Direction::NE);
     }
 
     public function testStraightTorpedoStillAvailableAfterDiagonal(): void
     {
         $game = Game::create(new FunRuleset());
         $game->placeFleet(FleetFactory::classic10x10());
-        $game->fireTorpedo(new Coordinate(0, 0), Direction::SE);
+        $game->fireTorpedo(new Coordinate(0, 2), Direction::SE);
 
         // druga torpeda (prosta) przechodzi — limit ogólny to 2
-        $results = $game->fireTorpedo(new Coordinate(0, 2), Direction::E);
+        $results = $game->fireTorpedo(new Coordinate(6, 0), Direction::E);
         $this->assertNotEmpty($results);
         $this->assertSame(2, $game->weaponsState()['torpedo']['used']);
     }

--- a/tests/Unit/GameWeaponLimitsTest.php
+++ b/tests/Unit/GameWeaponLimitsTest.php
@@ -33,9 +33,10 @@ it('odrzuca sonar w klasycznym rulesecie', function () {
 
 it('egzekwuje limit torped na grę', function () {
     $game = funGame();
-    $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+    // wyrzutnie = niszczyciele: (0,2)-(2,2) H oraz (6,0)-(6,2) V
     $game->fireTorpedo(new Coordinate(0, 2), Direction::E);
     $game->fireTorpedo(new Coordinate(6, 0), Direction::E);
+    $game->fireTorpedo(new Coordinate(6, 1), Direction::E);
 })->throws(DomainException::class, 'Torpedo limit reached');
 
 it('egzekwuje limit sonarów na grę', function () {
@@ -54,7 +55,7 @@ it('egzekwuje limit nalotów na grę', function () {
 
 it('raportuje stan broni: użycia i limity', function () {
     $game = funGame();
-    $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+    $game->fireTorpedo(new Coordinate(0, 2), Direction::E);
     $game->sonarPing(new Coordinate(5, 5));
 
     expect($game->weaponsState())->toBe([

--- a/tests/Unit/WeaponsFromFleetTest.php
+++ b/tests/Unit/WeaponsFromFleetTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Game\BoardSize;
+use App\Domain\Game\Coordinate;
+use App\Domain\Game\Direction;
+use App\Domain\Game\FunRuleset;
+use App\Domain\Game\Game;
+use App\Domain\Game\Orientation;
+use App\Domain\Game\Ship;
+use Tests\Support\FleetFactory;
+
+// Broń wynika ze składu floty: jedno użycie na nośnik
+// (torpeda=niszczyciel l3, sonar=kuter l2, nalot=lotniskowiec l4).
+
+it('limity broni wynikają ze składu floty', function () {
+    // flota wyprawy: kuter + 3 tratwy → tylko 1 sonar, zero torped i nalotów
+    $weapons = (new FunRuleset(new BoardSize(7, 7), [2 => 1, 1 => 3]))->weapons()->limits();
+
+    expect($weapons)->toBe(['torpedo' => 0, 'sonar' => 1, 'airRaid' => 0, 'torpedoDiagonal' => 0]);
+});
+
+it('flota klasyczna zachowuje dotychczasowe limity', function () {
+    expect((new FunRuleset())->weapons()->limits())
+        ->toBe(['torpedo' => 2, 'sonar' => 3, 'airRaid' => 1, 'torpedoDiagonal' => 1]);
+});
+
+it('zatopienie wszystkich kutrów odbiera sonar do końca bitwy', function () {
+    $game = Game::create(new FunRuleset());
+    $game->placeFleet(FleetFactory::classic10x10());
+
+    // kutry (l2) w klasycznym układzie: (5,4)-(6,4) H, (9,0)-(9,1) V, (3,6)-(3,7) V
+    foreach ([[5, 4], [6, 4], [9, 0], [9, 1], [3, 6], [3, 7]] as [$x, $y]) {
+        $game->fireOpponentShot(new Coordinate($x, $y));
+    }
+
+    expect(fn () => $game->sonarPing(new Coordinate(5, 5)))
+        ->toThrow(DomainException::class, 'Sonar requires an unsunk scout ship');
+    // nieudany ping nie zużywa limitu
+    expect($game->weaponsState()['sonar']['used'])->toBe(0);
+});
+
+it('zatopienie lotniskowca odbiera nalot do końca bitwy', function () {
+    $game = Game::create(new FunRuleset());
+    $game->placeFleet(FleetFactory::classic10x10());
+
+    // lotniskowiec (l4): (0,0)-(3,0)
+    foreach ([[0, 0], [1, 0], [2, 0], [3, 0]] as [$x, $y]) {
+        $game->fireOpponentShot(new Coordinate($x, $y));
+    }
+
+    expect(fn () => $game->sendAirRaid(new Coordinate(5, 5), new App\Domain\Game\Area(1, 1)))
+        ->toThrow(DomainException::class, 'Air raid requires an unsunk carrier');
+});
+
+it('legalne wyrzutnie torped AI to wyłącznie komórki jego niszczycieli', function () {
+    $game = Game::create(new FunRuleset());
+    $game->placeFleet(FleetFactory::classic10x10());
+    $game->placeOpponentFleet([
+        new Ship(new Coordinate(0, 0), Orientation::H, 4),
+        new Ship(new Coordinate(0, 2), Orientation::H, 3),
+        new Ship(new Coordinate(6, 0), Orientation::V, 3),
+        new Ship(new Coordinate(5, 4), Orientation::H, 2),
+        new Ship(new Coordinate(9, 0), Orientation::V, 2),
+        new Ship(new Coordinate(3, 6), Orientation::V, 2),
+        new Ship(new Coordinate(0, 6), Orientation::H, 1),
+        new Ship(new Coordinate(1, 8), Orientation::H, 1),
+        new Ship(new Coordinate(5, 9), Orientation::H, 1),
+        new Ship(new Coordinate(8, 8), Orientation::H, 1),
+    ]);
+
+    $cells = $game->opponentLaunchableCells();
+
+    // dwa niszczyciele × 3 komórki
+    expect($cells)->toHaveCount(6)
+        ->and($cells)->toContain(['x' => 0, 'y' => 2])
+        ->and($cells)->not->toContain(['x' => 0, 'y' => 0]); // lotniskowiec to nie wyrzutnia
+});
+
+it('torpeda floty wyprawy bez niszczyciela jest niedostępna', function () {
+    // kuter + 3 tratwy: limit torped 0 → 'not available'
+    $game = Game::create(new FunRuleset(new BoardSize(7, 7), [2 => 1, 1 => 3]));
+    $game->placeFleet([
+        new Ship(new Coordinate(0, 0), Orientation::H, 2),
+        new Ship(new Coordinate(4, 0), Orientation::H, 1),
+        new Ship(new Coordinate(6, 2), Orientation::H, 1),
+        new Ship(new Coordinate(0, 4), Orientation::H, 1),
+    ]);
+
+    $game->fireTorpedo(new Coordinate(0, 0), Direction::E);
+})->throws(DomainException::class, 'Torpedo not available in this ruleset');


### PR DESCRIPTION
Closes #32

Domknięcie Epic B (kroki 3+4): **broń wynika ze składu floty** + **UI portu**. Najmocniejszy element wizji z `docs/GAME_DESIGN.md` — bitwa dostaje nową warstwę taktyczną: poluj na nośniki przeciwnika, chroń swoje.

## Broń ze składu floty (krok 3)

- Nośniki (`Game::*_CARRIER_LENGTH`): **sonar = kuter (l2), torpeda = niszczyciel (l3), nalot = lotniskowiec (l4)** — bitwa zna tylko długości, mapowanie na typy floty wyprawy w komentarzu
- Torpeda startuje wyłącznie z niezatopionego **niszczyciela** (zaostrzenie dotychczasowej reguły „z żywego statku"); **zatopienie nośnika odbiera broń do końca bitwy** (walidacja przed zużyciem limitu — nieudana próba nie kosztuje)
- `FunRuleset`: limity = liczba nośników w składzie. Ładny zbieg okoliczności: flota klasyczna (2 niszczyciele, 3 kutry, 1 lotniskowiec) daje **dokładnie dotychczasowe limity 2/3/1** — zachowanie klasycznych gier fun bez zmian
- Flota wyprawy bez niszczyciela → torpeda „not available"; AI honoruje te same reguły (guardy w `OpponentTurn`, wyrzutnie AI = tylko komórki niszczycieli)
- Nowe kody błędów: `WEAPON_CARRIER_SUNK` (422)

## UI portu (krok 4)

- **Ekran wyprawy**: sekcja Flota (status statków + remont z kosztem), Stocznia (budowa z bramkami i czytelnymi powodami blokad: ranga / poziom stoczni / materiały), materiały w pasku profilu, nagrody materiałowe i poziom stoczni na kartach wysp
- **Bitwa**: przyciski broni gasną z tooltipem po utracie nośnika („Lotniskowiec zatopiony — naloty niedostępne"), wyrzutnie podświetlane tylko na niszczycielach, banner końca pokazuje `+XP +🔩` oraz stracone/uszkodzone statki

## Weryfikacja

- Unit `WeaponsFromFleetTest` (6): limity ze składu, klasyk bez zmian, zatopiony kuter/lotniskowiec odbiera broń bez zużycia limitu, wyrzutnie AI, flota bez niszczyciela
- Zaktualizowane testy torped pod regułę niszczyciela (wyrzutnie (0,2)/(6,0) w klasycznym układzie)
- `make test-unit` 95 ✓, `make test-func` 22 ✓, PHPStan/cs-fixer czyste, `npm run build` (vue-tsc) ✓
- E2E na dev: profil sprzed ekonomii dostał flotę startową, budowa kutra 20→0 🔩, natychmiastowa blokada „za mało materiałów", bramki rangowe widoczne w stoczni

🤖 Generated with [Claude Code](https://claude.com/claude-code)